### PR TITLE
Fixes for Crystal Ship and FTLFrame NPE

### DIFF
--- a/src/main/java/net/blerf/ftl/FTLProfileEditor.java
+++ b/src/main/java/net/blerf/ftl/FTLProfileEditor.java
@@ -1,9 +1,11 @@
 package net.blerf.ftl;
 
-import net.blerf.ftl.ui.FTLFrame;
+import javax.swing.UIManager;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import net.blerf.ftl.ui.FTLFrame;
 
 
 public class FTLProfileEditor {
@@ -13,6 +15,16 @@ public class FTLProfileEditor {
 	private static final int VERSION = 10;
 
 	public static void main(String[] args) {
+
+		// Set look and feel before the GUI.
+		// Otherwise, some existing components might not notice without this.
+		//   SwingUtilities.updateComponentTreeUI(someComponent);
+		// Maybe risks NPE if present in a JFrame constructor?
+		try {
+			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+		} catch (Exception e) {
+			log.error("Failed to set a native look and feel", e);
+		}
 
 		try {
 			FTLFrame frame = new FTLFrame(VERSION);

--- a/src/main/java/net/blerf/ftl/parser/DataManager.java
+++ b/src/main/java/net/blerf/ftl/parser/DataManager.java
@@ -124,7 +124,10 @@ public class DataManager {
 	}
 	
 	public ShipBlueprint getShip(String id) {
-		return ships.get(id);
+		ShipBlueprint result = ships.get(id);
+		if ( result == null )
+			log.error( "No ShipBlueprint found for id: "+ id );
+		return result;
 	}
 	
 	public List<ShipBlueprint> getPlayerShips() {

--- a/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
+++ b/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
@@ -113,6 +113,7 @@ public class MappedDatParser extends Parser implements Closeable {
 		sb.append("<blueprints>").append("\n");  // XML has multiple root nodes so need to wrap
 		boolean comment = false, inShipShields = false, inSlot = false;
 		while( (line = in.readLine()) != null ) {
+			line = line.replaceAll("<!-- sardonyx", "<!-- sardonyx -->");  // Error above one shipBlueprint
 			line = line.replaceAll("<!--.*-->", "");
 			line = line.replaceAll("<\\?xml[^>]*>", "");
 			line = line.replaceAll("<title>([^<]*)</[^>]*>", "<title>$1</title>");  // Error present in systemBlueprint and itemBlueprint

--- a/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
+++ b/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
@@ -113,7 +113,7 @@ public class MappedDatParser extends Parser implements Closeable {
 		sb.append("<blueprints>").append("\n");  // XML has multiple root nodes so need to wrap
 		boolean comment = false, inShipShields = false, inSlot = false;
 		while( (line = in.readLine()) != null ) {
-			line = line.replaceAll("<!-- sardonyx", "<!-- sardonyx -->");  // Error above one shipBlueprint
+			line = line.replaceAll("^<!-- sardonyx$", "<!-- sardonyx -->");  // Error above one shipBlueprint
 			line = line.replaceAll("<!--.*-->", "");
 			line = line.replaceAll("<\\?xml[^>]*>", "");
 			line = line.replaceAll("<title>([^<]*)</[^>]*>", "<title>$1</title>");  // Error present in systemBlueprint and itemBlueprint

--- a/src/main/java/net/blerf/ftl/ui/FTLFrame.java
+++ b/src/main/java/net/blerf/ftl/ui/FTLFrame.java
@@ -55,7 +55,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
-import javax.swing.UIManager;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.filechooser.FileFilter;
@@ -119,12 +118,6 @@ public class FTLFrame extends JFrame {
 	public FTLFrame(int version) {
 		
 		this.version = version;
-		
-		try {
-			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
 
 		// Read config file and locate FTL install
 		File propFile = new File("ftl-editor.cfg");


### PR DESCRIPTION
PLAYER_SHIP_CRYSTAL_2 was being omitted because, in blueprints xml, there was an unterminated comment above it.

This fixes the following issue.
https://github.com/ComaToes/ftl-profile-editor/issues/5

Changing Look and Feel in the JFrame constructor may have caused an NPE.
https://github.com/ComaToes/ftl-profile-editor/issues/7

I moved that, which I think is good practice anyway.
