### PR TITLE
Parsing Non-Player Ships, System Damage, etc.

### DIFF
--- a/src/main/java/net/blerf/ftl/FTLProfileEditor.java
+++ b/src/main/java/net/blerf/ftl/FTLProfileEditor.java
@@ -46,8 +46,8 @@ public class FTLProfileEditor {
 				writeConfig = true;  // Create a new cfg, but only if necessary.
 			}
 		} catch (IOException e) {
-			showErrorDialog( "Error loading config from " + propFile.getPath() );
 			log.error( "Error loading config", e );
+			showErrorDialog( "Error loading config from " + propFile.getPath() );
 		} finally {
 			if ( in != null ) { try { in.close(); } catch (IOException e) {} }
 		}
@@ -95,8 +95,8 @@ public class FTLProfileEditor {
 				config.store( out, "FTL Profile Editor - Config File" );
 
 			} catch (IOException e) {
-				showErrorDialog( "Error saving config to " + propFile.getPath() );
 				log.error( "Error saving config to " + propFile.getPath(), e );
+				showErrorDialog( "Error saving config to " + propFile.getPath() );
 
 			} finally {
 				if ( out != null ) { try { out.close(); } catch (IOException e) {} }
@@ -109,8 +109,9 @@ public class FTLProfileEditor {
 			DataManager.init( ftlPath );
 			
 		} catch (Exception e) {
-			showErrorDialog( "Error parsing FTL data files" );
 			log.error( "Error parsing FTL data files", e );
+			showErrorDialog( "Error parsing FTL data files" );
+			System.exit(1);
 		}
 
 		try {

--- a/src/main/java/net/blerf/ftl/parser/DataManager.java
+++ b/src/main/java/net/blerf/ftl/parser/DataManager.java
@@ -15,6 +15,7 @@ import net.blerf.ftl.model.ShipLayout;
 import net.blerf.ftl.xml.Achievement;
 import net.blerf.ftl.xml.Blueprints;
 import net.blerf.ftl.xml.ShipBlueprint;
+import net.blerf.ftl.xml.WeaponBlueprint;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,7 +37,8 @@ public class DataManager {
 	private List<Achievement> achievements;
 	private List<Achievement> generalAchievements;
 	private Blueprints blueprints;
-	
+
+	private Map<String, WeaponBlueprint> weapons;	
 	private Map<String, ShipBlueprint> ships;
 	private List<ShipBlueprint> playerShips; // Type A's
 	private Map<ShipBlueprint, List<Achievement>> shipAchievements;
@@ -65,10 +67,14 @@ public class DataManager {
 			for( Achievement ach : achievements )
 				if ( ach.getShipId() == null )
 					generalAchievements.add(ach);
-		
+
+			weapons = new HashMap<String, WeaponBlueprint>();
+			for ( WeaponBlueprint weapon : blueprints.getWeaponBlueprint() )
+				weapons.put( weapon.getId(), weapon );
+
 			ships = new HashMap<String, ShipBlueprint>();
 			for ( ShipBlueprint ship : blueprints.getShipBlueprint() )
-				ships.put( ship.getId() , ship );
+				ships.put( ship.getId(), ship );
 		
 			playerShips = new ArrayList<ShipBlueprint>();
 			playerShips.add( ships.get("PLAYER_SHIP_HARD") );
@@ -129,7 +135,14 @@ public class DataManager {
 		return achievements;
 	}
 	
-	public ShipBlueprint getShip(String id) {
+	public WeaponBlueprint getWeapon( String id ) {
+		WeaponBlueprint result = weapons.get(id);
+		if ( result == null )
+			log.error( "No WeaponBlueprint found for id: "+ id );
+		return result;
+	}
+
+	public ShipBlueprint getShip( String id ) {
 		ShipBlueprint result = ships.get(id);
 		if ( result == null )
 			log.error( "No ShipBlueprint found for id: "+ id );

--- a/src/main/java/net/blerf/ftl/parser/DataManager.java
+++ b/src/main/java/net/blerf/ftl/parser/DataManager.java
@@ -1,5 +1,6 @@
 package net.blerf.ftl.parser;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -20,7 +21,7 @@ import net.blerf.ftl.xml.WeaponBlueprint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class DataManager {
+public class DataManager implements Closeable {
 	
 	private static final Logger log = LogManager.getLogger(DataManager.class);
 
@@ -101,11 +102,7 @@ public class DataManager {
 		
 		} catch (IOException e) {
 			log.error( "Error while constructing DataManager", e );
-
-			try {if (dataParser != null) dataParser.close();}
-			catch (IOException f) {}
-			try {if (resourceParser != null) resourceParser.close();}
-			catch (IOException f) {}
+			this.close();
 
 		} finally {
 			try {if (ach_stream != null) ach_stream.close();}
@@ -113,6 +110,14 @@ public class DataManager {
 			try {if (blue_stream != null) blue_stream.close();}
 			catch (IOException f) {}
 		}
+	}
+
+	public void close() {
+		try {if (dataParser != null) dataParser.close();}
+		catch (IOException e) {}
+
+		try {if (resourceParser != null) resourceParser.close();}
+		catch (IOException e) {}
 	}
 	
 	public InputStream getDataInputStream( String innerPath ) throws IOException {

--- a/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
+++ b/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
@@ -273,14 +273,17 @@ public class MappedDatParser extends Parser implements Closeable {
 		public ByteBufferBackedInputStream(ByteBuffer buf) {
 			this.buf = buf;
 		}
-		public synchronized int remaining() throws IOException {
+		@Override
+		public synchronized int available() throws IOException {
 			if (!buf.hasRemaining()) return 0;
 			return buf.remaining();
 		}
+		@Override
 		public synchronized int read() throws IOException {
 			if (!buf.hasRemaining()) return -1;
 			return buf.get() & 0xFF;
 		}
+		@Override
 		public synchronized int read(byte[] bytes, int off, int len) throws IOException {
 			if (!buf.hasRemaining()) return -1;
 			len = Math.min(len, buf.remaining());

--- a/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
+++ b/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
@@ -273,7 +273,7 @@ public class MappedDatParser extends Parser implements Closeable {
 		public ByteBufferBackedInputStream(ByteBuffer buf) {
 			this.buf = buf;
 		}
-		public synchronized int available() throws IOException {
+		public synchronized int remaining() throws IOException {
 			if (!buf.hasRemaining()) return 0;
 			return buf.remaining();
 		}

--- a/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
+++ b/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
@@ -118,6 +118,7 @@ public class MappedDatParser extends Parser implements Closeable {
 
 		boolean comment = false, inShipShields = false, inSlot = false;
 		while( (line = in.readLine()) != null ) {
+			// blueprints.xml
 			line = line.replaceAll("^<!-- sardonyx$", "<!-- sardonyx -->");  // Error above one shipBlueprint
 			line = line.replaceAll("<!--.*-->", "");
 			line = line.replaceAll("<\\?xml[^>]*>", "");
@@ -142,6 +143,10 @@ public class MappedDatParser extends Parser implements Closeable {
 				} else if (line.contains("</shields>"))
 					inShipShields = false;
 			}
+
+			// autoBlueprints.xml
+			line = line.replaceAll("\"max=", "\" max=");  // ahhhh
+			line = line.replaceAll("\"room=", "\" room=");  // ahhhh
 
 			// Remove multiline comments
 			if (comment && line.contains("-->"))

--- a/src/main/java/net/blerf/ftl/parser/Parser.java
+++ b/src/main/java/net/blerf/ftl/parser/Parser.java
@@ -1,5 +1,6 @@
 package net.blerf.ftl.parser;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,9 +68,16 @@ public class Parser {
 			if ( length > fin.getChannel().size() - position)
 				throw new RuntimeException( "Expected string length ("+ length +") would extend beyond the end of the stream, from current position ("+ position +")" );
 		}
-		else if ( in instanceof MappedDatParser.ByteBufferBackedInputStream ) {
-			int remaining = ((MappedDatParser.ByteBufferBackedInputStream)in).remaining();
-			if (length > remaining )
+		else {
+			// Call available on streams that really end.
+			int remaining = -1;
+			if ( in instanceof MappedDatParser.ByteBufferBackedInputStream ) {
+				remaining = ((MappedDatParser.ByteBufferBackedInputStream)in).available();
+			}
+			else if ( in instanceof ByteArrayInputStream ) {
+				remaining = ((ByteArrayInputStream)in).available();
+			}
+			if (remaining != -1 && length > remaining )
 				throw new RuntimeException( "Expected string length ("+ length +") would extend beyond the end of the stream" );
 		}
 		

--- a/src/main/java/net/blerf/ftl/parser/Parser.java
+++ b/src/main/java/net/blerf/ftl/parser/Parser.java
@@ -1,8 +1,12 @@
 package net.blerf.ftl.parser;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
+import net.blerf.ftl.parser.MappedDatParser;
+
 
 public class Parser {
 	
@@ -21,7 +25,13 @@ public class Parser {
 
 	protected int readInt(InputStream in) throws IOException {
 		
-		in.read(intbuf);
+		int numRead = 0;
+		int offset = 0;
+		while (offset < intbuf.length && (numRead = in.read(intbuf, offset, intbuf.length)) >= 0)
+			offset += numRead;
+
+		if (offset < intbuf.length)
+			throw new RuntimeException( "End of stream reached before reading enough bytes for an int" );
 		
 		int v = 0;
 		
@@ -46,10 +56,31 @@ public class Parser {
 	protected String readString(InputStream in) throws IOException {
 		
 		int length = readInt(in);
+
+		// Avoid allocating a rediculous array size.
+		// But InputStreams don't universally track position/size.
+		// And available() might only mean blocking, not the end.
+		// So try some special cases...
+		if ( in instanceof FileInputStream ) {
+			FileInputStream fin = (FileInputStream)in;
+			long position = fin.getChannel().position();
+			if ( length > fin.getChannel().size() - position)
+				throw new RuntimeException( "Expected string length ("+ length +") would extend beyond the end of the stream, from current position ("+ position +")" );
+		}
+		else if ( in instanceof MappedDatParser.ByteBufferBackedInputStream ) {
+			int remaining = ((MappedDatParser.ByteBufferBackedInputStream)in).remaining();
+			if (length > remaining )
+				throw new RuntimeException( "Expected string length ("+ length +") would extend beyond the end of the stream" );
+		}
 		
+		int numRead = 0;
+		int offset = 0;
 		byte[] strarr = new byte[length];
-		
-		in.read(strarr);
+		while (offset < strarr.length && (numRead = in.read(strarr, offset, strarr.length)) >= 0)
+			offset += numRead;
+
+		if ( offset < strarr.length )
+			throw new RuntimeException( "End of stream reached before reading enough bytes for string of length "+ length );
 		
 		return new String(strarr);
 		

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -157,8 +157,8 @@ public class SavedGameParser extends DatParser {
 		for (int i=0; i < weaponCount; i++) {
 			String weaponId = readString(in);
 			int weaponArmed = readInt(in);
-			int weaponAlpha = readInt(in);  // ? (0 when not armed)
-			shipState.addWeapon( new WeaponState(weaponId, weaponArmed, weaponAlpha) );
+			int weaponCooldownTicks = readInt(in);
+			shipState.addWeapon( new WeaponState(weaponId, weaponArmed, weaponCooldownTicks) );
 		}
 
 		int droneCount = readInt(in);

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -18,6 +18,7 @@ import net.blerf.ftl.model.ShipLayout;
 import net.blerf.ftl.parser.DataManager;
 import net.blerf.ftl.parser.MysteryBytes;
 import net.blerf.ftl.xml.ShipBlueprint;
+import net.blerf.ftl.xml.WeaponBlueprint;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -867,21 +868,24 @@ public class SavedGameParser extends DatParser {
 	public class WeaponState {
 		private String weaponId;
 		private int armed;
-		private int unknownAlpha;
+		private int cooldownTicks;  // Increments from 0 until the weapon's cooldown.
 
-		public WeaponState( String weaponId, int armed, int alpha ) {
+		public WeaponState( String weaponId, int armed, int cooldownTicks ) {
 			this.weaponId = weaponId;
 			this.armed = armed;
-			this.unknownAlpha = alpha;
+			this.cooldownTicks = cooldownTicks;
 		}
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
-			result.append(String.format("WeaponId: %s\n", weaponId));
-			result.append(String.format("Armed: %d\n", armed));
-			result.append("/ / / Unknowns / / /\n");
-			result.append(String.format("Alpha: %d\n", unknownAlpha));
+
+			WeaponBlueprint weaponBlueprint = DataManager.get().getWeapon(weaponId);
+			String cooldownString = ( weaponBlueprint!=null ? weaponBlueprint.getCooldown()+"" : "?" );
+
+			result.append(String.format("WeaponId:       %s\n", weaponId));
+			result.append(String.format("Armed:          %d\n", armed));
+			result.append(String.format("Cooldown Ticks: %d (max: %s)\n", cooldownTicks, cooldownString));
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -219,7 +219,8 @@ public class SavedGameParser extends DatParser {
 		if (capacity > 0) {
 			system.setCapacity( capacity );
 			system.setPower( readInt(in) );
-			system.addMysteryBytes( new MysteryBytes(in, 12) );
+			system.setDamagedBars( readInt(in) );
+			system.addMysteryBytes( new MysteryBytes(in, 8) );
 			system.setRepairProgress( readInt(in) );
 			system.setBurnProgress( readInt(in) );
 		}
@@ -767,6 +768,7 @@ public class SavedGameParser extends DatParser {
 		private String name;
 		private int capacity = 0;
 		private int power = 0;
+		private int damagedBars = 0;     // Number of unusable power bars.
 		private int repairProgress = 0;  // Turns bar yellow.
 		private int burnProgress = 0;    // Turns bar red.
 
@@ -778,6 +780,7 @@ public class SavedGameParser extends DatParser {
 
 		public void setCapacity( int n ) { capacity = n; }
 		public void setPower( int n ) { power = n; }
+		public void setDamagedBars( int n ) { damagedBars = n; }
 		public void setRepairProgress( int n ) { repairProgress = n; }
 		public void setBurnProgress( int n ) { burnProgress = n; }
 
@@ -788,8 +791,9 @@ public class SavedGameParser extends DatParser {
 			StringBuilder result = new StringBuilder();
 			if (capacity > 0) {
 				result.append(String.format("%s: %d/%d Power\n", name, power, capacity));
+				result.append(String.format("Damaged Bars:    %d\n", damagedBars));
 				result.append(String.format("Repair Progress: %d%%\n", repairProgress));
-				result.append(String.format("Burn Progress: %d%%\n", burnProgress));
+				result.append(String.format("Burn Progress:   %d%%\n", burnProgress));
 				result.append("/ / / Unknowns / / /\n");
 				if ( mysteryList.size() > 0 ) {
 					result.append("Mystery Bytes...\n");

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -206,7 +206,7 @@ public class SavedGameParser extends DatParser {
 		crew.setY( readInt(in) );
 		crew.setRoomId( readInt(in) );
 		crew.setRoomSquare( readInt(in) );   // 0-based, as a wrapped H row.
-		crew.setEpsilon( readInt(in) );      // Always 1?
+		crew.setPlayerControlled( readBool(in) );
 		crew.setPilotSkill( readInt(in) );
 		crew.setEngineSkill( readInt(in) );
 		crew.setShieldSkill( readInt(in) );
@@ -218,7 +218,7 @@ public class SavedGameParser extends DatParser {
 		crew.setTheta( readInt(in) );        // Matches combat, sometimes less?
 		crew.setKappa( readInt(in) );
 		crew.setJumpsSurvived( readInt(in) );
-		crew.setIota( readInt(in) );         // ?
+		crew.setIota( readInt(in) );         // Increments to 1 at first mastery?
 		return crew;
 	}
 
@@ -756,9 +756,19 @@ public class SavedGameParser extends DatParser {
 
 
 	public class CrewState {
+		// TODO: magic numbers.
+		// Make these static when the class gets its own file.
+		public final int MASTERY_INTERVAL_PILOT = 15;
+		public final int MASTERY_INTERVAL_ENGINE = 15;
+		public final int MASTERY_INTERVAL_SHIELD = 55;
+		public final int MASTERY_INTERVAL_WEAPON = 65;
+		public final int MASTERY_INTERVAL_REPAIR = 18;
+		public final int MASTERY_INTERVAL_COMBAT = 8;
+
 		private String name, race;
 		private int health;
 		private int blueprintRoomId, roomSquare;
+		private boolean playerControlled;
 		private int pilotSkill, engineSkill, shieldSkill;
 		private int weaponSkill, repairSkill, combatSkill;
 		private int jumpsSurvived;
@@ -777,6 +787,7 @@ public class SavedGameParser extends DatParser {
 		public void setHealth( int n ) {health = n; }
 		public void setRoomId( int n ) {blueprintRoomId = n; }
 		public void setRoomSquare( int n ) { roomSquare = n; }
+		public void setPlayerControlled( boolean b ) { playerControlled = b; }
 		public void setPilotSkill( int n ) {pilotSkill = n; }
 		public void setEngineSkill( int n ) {engineSkill = n; }
 		public void setShieldSkill( int n ) {shieldSkill = n; }
@@ -800,25 +811,25 @@ public class SavedGameParser extends DatParser {
 			StringBuilder result = new StringBuilder();
 			result.append(String.format("Name: %s\n", name));
 			result.append(String.format("Race: %s\n", race));
-			result.append(String.format("Health:         %3d\n", health));
-			result.append(String.format("RoomId:         %3d\n", blueprintRoomId));
-			result.append(String.format("Room Square:    %3d\n", roomSquare));
-			result.append(String.format("Pilot Skill:    %3d\n", pilotSkill));
-			result.append(String.format("Engine Skill:   %3d\n", engineSkill));
-			result.append(String.format("Shield Skill:   %3d\n", shieldSkill));
-			result.append(String.format("Weapon Skill:   %3d\n", weaponSkill));
-			result.append(String.format("Repair Skill:   %3d\n", repairSkill));
-			result.append(String.format("Combat Skill?:  %3d\n", combatSkill));
-			result.append(String.format("Jumps Survived: %3d\n", jumpsSurvived));
-			result.append(String.format("Position:       (%d,%d)\n", x, y));
-			result.append(String.format("Gender:         %s\n", gender == 1 ? "Male" : "Female" ));
+			result.append(String.format("Health:           %3d\n", health));
+			result.append(String.format("RoomId:           %3d\n", blueprintRoomId));
+			result.append(String.format("Room Square:      %3d\n", roomSquare));
+			result.append(String.format("Player Controlled: %3s\n", playerControlled));
+			result.append(String.format("Pilot Skill:      %3d (Mastery Interval: %2d)\n", pilotSkill, MASTERY_INTERVAL_PILOT));
+			result.append(String.format("Engine Skill:     %3d (Mastery Interval: %2d)\n", engineSkill, MASTERY_INTERVAL_ENGINE));
+			result.append(String.format("Shield Skill:     %3d (Mastery Interval: %2d)\n", shieldSkill, MASTERY_INTERVAL_SHIELD));
+			result.append(String.format("Weapon Skill:     %3d (Mastery Interval: %2d)\n", weaponSkill, MASTERY_INTERVAL_WEAPON));
+			result.append(String.format("Repair Skill:     %3d (Mastery Interval: %2d)\n", repairSkill, MASTERY_INTERVAL_REPAIR));
+			result.append(String.format("Combat Skill?:    %3d (Mastery Interval: %2d)\n", combatSkill, MASTERY_INTERVAL_COMBAT));
+			result.append(String.format("Jumps Survived:   %3d\n", jumpsSurvived));
+			result.append(String.format("Position:         (%d,%d)\n", x, y));
+			result.append(String.format("Gender:           %s\n", gender == 1 ? "Male" : "Female" ));
 			result.append("/ / / Unknowns / / /\n");
-			result.append(String.format("Alpha:          %3d\n", unknownAlpha));
-			result.append(String.format("Epsilon:        %3d\n", unknownEpsilon));
-			result.append(String.format("Eta:            %3d\n", unknownEta));
-			result.append(String.format("Theta:          %3d\n", unknownTheta));
-			result.append(String.format("Kappa:          %3d\n", unknownKappa));
-			result.append(String.format("Iota:           %3d\n", unknownIota));
+			result.append(String.format("Alpha:            %3d\n", unknownAlpha));
+			result.append(String.format("Eta:              %3d\n", unknownEta));
+			result.append(String.format("Theta:            %3d\n", unknownTheta));
+			result.append(String.format("Kappa:            %3d\n", unknownKappa));
+			result.append(String.format("Iota:             %3d\n", unknownIota));
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -89,6 +89,14 @@ public class SavedGameParser extends DatParser {
 				gameState.addQuestEvent( questEventId, questAlpha );
 			}
 
+			gameState.addMysteryBytes( new MysteryBytes(in, 8) );
+
+			boolean shipNearby = readBool(in);
+			if ( shipNearby ) {
+				ShipState nearbyShipState = readShip( in, false );
+				gameState.setNearbyShipState(nearbyShipState);
+			}
+
 			int bytesRemaining = (int)(in.getChannel().size() - in.getChannel().position());
 			gameState.addMysteryBytes( new MysteryBytes(in, bytesRemaining) );
 
@@ -374,6 +382,7 @@ public class SavedGameParser extends DatParser {
 		private List<Integer> mysteryIntList;
 		private List<BeaconState> beaconList = new ArrayList<BeaconState>();
 		private LinkedHashMap<String, Integer> questEventMap = new LinkedHashMap<String, Integer>();
+		private ShipState nearbyShipState = null;
 		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
 		public void setSectorNumber( int n ) { sectorNumber = n; }
@@ -423,6 +432,10 @@ public class SavedGameParser extends DatParser {
 			questEventMap.put( questEventId, new Integer(questAlpha) );
 		}
 
+		public void setNearbyShipState( ShipState shipState ) {
+			this.nearbyShipState = shipState;
+		}
+
 		public void addMysteryBytes( MysteryBytes m ) {
 			mysteryList.add(m);
 		}
@@ -465,6 +478,10 @@ public class SavedGameParser extends DatParser {
 				int questAlpha = entry.getValue().intValue();
 				result.append(String.format("QuestEventId: %s, Alpha: %d\n", questEventId, questAlpha));
 			}
+
+			result.append("\nNearby Ship...\n");
+			if ( nearbyShipState != null )
+				result.append(nearbyShipState.toString().replaceAll("(^|\n)(.+)", "$1  $2"));
 
 			result.append("\nMystery Bytes...\n");
 			first = true;

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -785,7 +785,7 @@ public class SavedGameParser extends DatParser {
 		public void setCombatSkill( int n ) {combatSkill = n; }
 		public void setJumpsSurvived( int n ) {jumpsSurvived = n; }
 		public void setX( int x ) { this.x = x; };
-		public void setY( int y ) { this.y = x; };
+		public void setY( int y ) { this.y = y; };
 		public void setGender( int gender ) { this.gender = gender; }
 
 		public void setAlpha( int n ) { unknownAlpha = n; }

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -200,13 +200,13 @@ public class SavedGameParser extends DatParser {
 		crew.setPilotSkill( readInt(in) );
 		crew.setEngineSkill( readInt(in) );
 		crew.setShieldSkill( readInt(in) );
-		crew.setWeaponSkill( readInt(in) );  // Maybe
+		crew.setWeaponSkill( readInt(in) );
 		crew.setRepairSkill( readInt(in) );
-		crew.setDigamma( readInt(in) );      // ?
+		crew.setCombatSkill( readInt(in) );  // Maybe
 		crew.setGender( readInt(in) );       // 1 == male, 0 == female (only human females are 0, prob because other races don't have female gfx)
 		crew.setEta( readInt(in) );          // Matches repair?
-		crew.setTheta( readInt(in) );        // Matches digamma?
-		crew.setCombatSkill( readInt(in) );  // Maybe
+		crew.setTheta( readInt(in) );        // Matches combat, sometimes less?
+		crew.setKappa( readInt(in) );
 		crew.setJumpsSurvived( readInt(in) );
 		crew.setIota( readInt(in) );         // ?
 		return crew;
@@ -741,7 +741,7 @@ public class SavedGameParser extends DatParser {
 
 		private int unknownAlpha;
 		private int unknownEpsilon, unknownDigamma, unknownEta;
-		private int unknownTheta, unknownIota;
+		private int unknownTheta, unknownKappa, unknownIota;
 
 		public CrewState() {
 		}
@@ -764,9 +764,9 @@ public class SavedGameParser extends DatParser {
 
 		public void setAlpha( int n ) { unknownAlpha = n; }
 		public void setEpsilon( int n ) { unknownEpsilon = n; }
-		public void setDigamma( int n ) { unknownDigamma = n; }
 		public void setEta( int n ) { unknownEta = n; }
 		public void setTheta( int n ) { unknownTheta = n; }
+		public void setKappa( int n ) { unknownKappa = n; }
 		public void setIota( int n ) { unknownIota = n; }
 
 		@Override
@@ -780,7 +780,7 @@ public class SavedGameParser extends DatParser {
 			result.append(String.format("Pilot Skill:    %3d\n", pilotSkill));
 			result.append(String.format("Engine Skill:   %3d\n", engineSkill));
 			result.append(String.format("Shield Skill:   %3d\n", shieldSkill));
-			result.append(String.format("Weapon Skill?:  %3d\n", weaponSkill));
+			result.append(String.format("Weapon Skill:   %3d\n", weaponSkill));
 			result.append(String.format("Repair Skill:   %3d\n", repairSkill));
 			result.append(String.format("Combat Skill?:  %3d\n", combatSkill));
 			result.append(String.format("Jumps Survived: %3d\n", jumpsSurvived));
@@ -789,9 +789,9 @@ public class SavedGameParser extends DatParser {
 			result.append("/ / / Unknowns / / /\n");
 			result.append(String.format("Alpha:          %3d\n", unknownAlpha));
 			result.append(String.format("Epsilon:        %3d\n", unknownEpsilon));
-			result.append(String.format("Digamma:        %3d\n", unknownDigamma));
 			result.append(String.format("Eta:            %3d\n", unknownEta));
 			result.append(String.format("Theta:          %3d\n", unknownTheta));
+			result.append(String.format("Kappa:          %3d\n", unknownKappa));
 			result.append(String.format("Iota:           %3d\n", unknownIota));
 			return result.toString();
 		}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -234,7 +234,8 @@ public class SavedGameParser extends DatParser {
 			system.setCapacity( capacity );
 			system.setPower( readInt(in) );
 			system.setDamagedBars( readInt(in) );
-			system.addMysteryBytes( new MysteryBytes(in, 8) );
+			system.setIonizedBars( readInt(in) );
+			system.addMysteryBytes( new MysteryBytes(in, 4) );
 			system.setRepairProgress( readInt(in) );
 			system.setBurnProgress( readInt(in) );
 		}
@@ -829,6 +830,7 @@ public class SavedGameParser extends DatParser {
 		private int capacity = 0;
 		private int power = 0;
 		private int damagedBars = 0;     // Number of unusable power bars.
+		private int ionizedBars = 0;     // Number of disabled power bars.
 		private int repairProgress = 0;  // Turns bar yellow.
 		private int burnProgress = 0;    // Turns bar red.
 
@@ -841,6 +843,7 @@ public class SavedGameParser extends DatParser {
 		public void setCapacity( int n ) { capacity = n; }
 		public void setPower( int n ) { power = n; }
 		public void setDamagedBars( int n ) { damagedBars = n; }
+		public void setIonizedBars( int n ) { ionizedBars = n; }
 		public void setRepairProgress( int n ) { repairProgress = n; }
 		public void setBurnProgress( int n ) { burnProgress = n; }
 
@@ -852,6 +855,7 @@ public class SavedGameParser extends DatParser {
 			if (capacity > 0) {
 				result.append(String.format("%s: %d/%d Power\n", name, power, capacity));
 				result.append(String.format("Damaged Bars:    %d\n", damagedBars));
+				result.append(String.format("Ionized Bars:    %d\n", ionizedBars));
 				result.append(String.format("Repair Progress: %d%%\n", repairProgress));
 				result.append(String.format("Burn Progress:   %d%%\n", burnProgress));
 				result.append("/ / / Unknowns / / /\n");

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -348,15 +348,15 @@ public class SavedGameParser extends DatParser {
 	// Stash state classes here until they're finalized.
 
 	public class SavedGameState {
-		public String playerShipName = "";
-		public String playerShipBlueprintId = "";
-		public int sectorNumber = 1;
-		public HashMap<String,Integer> stateVars = new HashMap<String,Integer>();
-		public ShipState playerShipState = null;
-		public int sectorLayoutSeed, rebelFleetOffset;
-		public List<Integer> mysteryIntList;
-		public List<BeaconState> beacons = new ArrayList<BeaconState>();
-		public ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
+		private String playerShipName = "";
+		private String playerShipBlueprintId = "";
+		private int sectorNumber = 1;
+		private HashMap<String,Integer> stateVars = new HashMap<String,Integer>();
+		private ShipState playerShipState = null;
+		private int sectorLayoutSeed, rebelFleetOffset;
+		private List<Integer> mysteryIntList;
+		private List<BeaconState> beacons = new ArrayList<BeaconState>();
+		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
 		public void setSectorNumber( int n ) { sectorNumber = n; }
 
@@ -451,21 +451,21 @@ public class SavedGameParser extends DatParser {
 
 
 	public class ShipState {
-		public boolean playerControlled = false;
-		public String shipName, shipBlueprintId, shipLayoutId;
-		public ArrayList<StartingCrewState> startingCrewList = new ArrayList<StartingCrewState>();
-		public int hullAmt, fuelAmt, dronePartsAmt, missilesAmt, scrapAmt;
-		public ArrayList<CrewState> crewList = new ArrayList<CrewState>();
-		public int reservePowerCapacity;
-		public ArrayList<SystemState> systemList = new ArrayList<SystemState>();
-		public ArrayList<RoomState> roomList = new ArrayList<RoomState>();
-		public LinkedHashMap<Point, Integer> warningLightMap = new LinkedHashMap<Point, Integer>();
-		public LinkedHashMap<int[], DoorState> doorMap = new LinkedHashMap<int[], DoorState>();
-		public ArrayList<WeaponState> weaponList = new ArrayList<WeaponState>();
-		public ArrayList<DroneState> droneList = new ArrayList<DroneState>();
-		public ArrayList<String> augmentIdList = new ArrayList<String>();
-		public ArrayList<String> cargoIdList = new ArrayList<String>();
-		public ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
+		private boolean playerControlled = false;
+		private String shipName, shipBlueprintId, shipLayoutId;
+		private ArrayList<StartingCrewState> startingCrewList = new ArrayList<StartingCrewState>();
+		private int hullAmt, fuelAmt, dronePartsAmt, missilesAmt, scrapAmt;
+		private ArrayList<CrewState> crewList = new ArrayList<CrewState>();
+		private int reservePowerCapacity;
+		private ArrayList<SystemState> systemList = new ArrayList<SystemState>();
+		private ArrayList<RoomState> roomList = new ArrayList<RoomState>();
+		private LinkedHashMap<Point, Integer> warningLightMap = new LinkedHashMap<Point, Integer>();
+		private LinkedHashMap<int[], DoorState> doorMap = new LinkedHashMap<int[], DoorState>();
+		private ArrayList<WeaponState> weaponList = new ArrayList<WeaponState>();
+		private ArrayList<DroneState> droneList = new ArrayList<DroneState>();
+		private ArrayList<String> augmentIdList = new ArrayList<String>();
+		private ArrayList<String> cargoIdList = new ArrayList<String>();
+		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
 		public ShipState(String shipName, String shipBlueprintId, String shipLayoutId, boolean playerControlled) {
 			this.shipName = shipName;
@@ -807,7 +807,7 @@ public class SavedGameParser extends DatParser {
 		private int repairProgress = 0;  // Turns bar yellow.
 		private int burnProgress = 0;    // Turns bar red.
 
-		public ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
+		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
 		public SystemState( String name ) {
 			this.name = name;
@@ -850,7 +850,7 @@ public class SavedGameParser extends DatParser {
 
 	public class RoomState {
 		private int oxygen = 100;
-		public ArrayList<int[]> squareList = new ArrayList<int[]>();
+		private ArrayList<int[]> squareList = new ArrayList<int[]>();
 
 		public void setOxygen( int n ) { oxygen = n; }
 

--- a/src/main/java/net/blerf/ftl/ui/FTLFrame.java
+++ b/src/main/java/net/blerf/ftl/ui/FTLFrame.java
@@ -428,7 +428,7 @@ public class FTLFrame extends JFrame {
 						
 					} catch( Exception f ) {
 						log.error( "Error reading profile", f );
-						showErrorDialog( "Error reading profile: " + f.getMessage() );
+						showErrorDialog( "Error reading profile:\n" + f.getMessage() );
 					} finally {
 						try {if (raf != null) raf.close();}
 						catch (IOException g) {}
@@ -460,7 +460,7 @@ public class FTLFrame extends JFrame {
 						
 					} catch( IOException f ) {
 						log.error( "Error writing profile", f );
-						showErrorDialog( "Error saving profile: " + f.getMessage() );
+						showErrorDialog( "Error saving profile:\n" + f.getMessage() );
 					} finally {
 						try {if (out != null) out.close();}
 						catch (IOException g) {}
@@ -524,8 +524,8 @@ public class FTLFrame extends JFrame {
 						JOptionPane.showMessageDialog(FTLFrame.this, "All dat content extracted successfully.", "Extraction Complete", JOptionPane.PLAIN_MESSAGE);
 						
 					} catch( IOException ex ) {
-						log.error("Error extracting dat",ex);
-						showErrorDialog("Error extracting dat: " + ex.getMessage());
+						log.error("Error extracting dat", ex);
+						showErrorDialog("Error extracting dat:\n" + ex.getMessage());
 					}
 				} else
 					log.trace("Extract dialog cancelled");
@@ -589,7 +589,7 @@ public class FTLFrame extends JFrame {
 						
 					} catch( Exception f ) {
 						log.error( "Error reading saved game", f );
-						showErrorDialog( "Error reading saved game: " + f.getMessage() );
+						showErrorDialog( "Error reading saved game:\n" + f.getMessage() );
 					}
 				} else {
 					log.trace( "Open dialog cancelled" );
@@ -629,7 +629,7 @@ public class FTLFrame extends JFrame {
 						
 					} catch( IOException f ) {
 						log.error( "Error dumping saved game", f );
-						showErrorDialog( "Error dumping saved game: "+ f.getMessage() );
+						showErrorDialog( "Error dumping saved game:\n"+ f.getMessage() );
 					} finally {
 						try {if (out != null) out.close();}
 						catch (IOException g) {}
@@ -771,7 +771,7 @@ public class FTLFrame extends JFrame {
 			
 		} catch (Exception e) {
 			log.error( "Error checking for latest version", e );
-			showErrorDialog( "Error checking for latest version\n(Use the About window to check the download page manually)\n"+ e );
+			showErrorDialog( "Error checking for latest version.\n(Use the About window to check the download page manually)\n"+ e );
 
 		} finally {
 			try {if (in != null) in.close();}

--- a/src/main/java/net/blerf/ftl/xml/WeaponBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/WeaponBlueprint.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -11,11 +12,17 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class WeaponBlueprint {
 	
+	@XmlAttribute(name="name")
+	private String id;
 	private String type, title;
 	@XmlElement(name="short")
 	private String shortTitle;
 	private String desc, tooltip;
-	private int damage, shots, sp, fireChance, breachChance, cooldown, power, cost, bp, rarity;
+	@XmlElement(name="sp")
+	private int shieldPiercing;
+	@XmlElement(name="bp")
+	private int bp;  // TODO: Rename this.
+	private int damage, shots, fireChance, breachChance, cooldown, power, cost, rarity;
 	private String image;
 	private SoundList launchSounds, hitShipSounds, hitShieldSounds, missSounds;
 	private String weaponArt;
@@ -26,4 +33,125 @@ public class WeaponBlueprint {
 		private List<String> sound;
 	}
 
+	public String getId() {
+		return id;
+	}
+
+	public void setId( String id ) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType( String type ) {
+		this.type = type;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle( String title ) {
+		this.title = title;
+	}
+
+	public String getShortTitle() {
+		return shortTitle;
+	}
+
+	public void setShortTitle( String shortTitle ) {
+		this.shortTitle = shortTitle;
+	}
+
+	public String getDescription() {
+		return desc;
+	}
+
+	public void setDescription( String desc ) {
+		this.desc = desc;
+	}
+
+	public String getTooltip() {
+		return tooltip;
+	}
+
+	public void setTooltip( String tooltip ) {
+		this.tooltip = tooltip;
+	}
+
+	public int getShieldPiercing() {
+		return shieldPiercing;
+	}
+
+	public void setShieldPiercing( int shieldPiercing ) {
+		this.shieldPiercing = shieldPiercing;
+	}
+
+	// TODO: bp?
+
+	public int getDamage() {
+		return damage;
+	}
+
+	public void setDamage( int damage ) {
+		this.damage = damage;
+	}
+
+	public int getShots() {
+		return shots;
+	}
+
+	public void setShots( int shots ) {
+		this.shots = shots;
+	}
+
+	public int getFireChance() {
+		return fireChance;
+	}
+
+	public void setFireChance( int fireChance ) {
+		this.fireChance = fireChance;
+	}
+
+	public int getBreachChance() {
+		return breachChance;
+	}
+
+	public void setBreachChance( int breachChance ) {
+		this.breachChance = breachChance;
+	}
+
+	public int getCooldown() {
+		return cooldown;
+	}
+
+	public void setCooldown( int cooldown ) {
+		this.cooldown = cooldown;
+	}
+
+	public int getPower() {
+		return power;
+	}
+
+	public void setPower( int power ) {
+		this.power = power;
+	}
+
+	public int getCost() {
+		return cost;
+	}
+
+	public void setCost( int cost ) {
+		this.cost = cost;
+	}
+
+	public int getRarity() {
+		return cost;
+	}
+
+	public void setRarity( int rarity ) {
+		this.rarity = rarity;
+	}
 }


### PR DESCRIPTION
SavedGameState
- Quest events
- nearbyShip

ShipState
- breach warning lights
- nearbyShip
- Stored layoutId turned out to be unreliable for pirate ships. The blueprint's layout is used instead.

CrewState
- playerControlled
- Magic numbers for skill mastery thresholds
- Fixed the unknown Y being reported with X's value.
- Changed the guess for combat skill.

SystemState
- damagedBars
- ionizedBars

WeaponState
- cooldownTicks

Parser.readX methods were made less likely to be fooled into reading too far, or allocating rediculous amounts of memory when a position glitch feeds them unexpected bytes. They print the offending value and throw exceptions that are handled cleanly, instead of an OutOfMemoryError.

MappedDatParser
- Strips unicode byte-order marks from files it reads
- Echoes typoed xml lines to the logger when unmarshalling fails.
- Fixes autoBlueprints.xml

DataManager
- Reads autoBlueprints.xml (For now, getShip() just searches both the ships map and autoShips map and returns whichever has a non-null result)
