### PR TITLE
Totals, Sector, and Drone Stuff

### DIFF
--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -89,7 +89,13 @@ public class SavedGameParser extends DatParser {
 				gameState.addQuestEvent( questEventId, questBeaconId );
 			}
 
-			gameState.addMysteryBytes( new MysteryBytes(in, 8) );
+			int distantQuestEventCount = readInt(in);
+			for (int i=0; i < distantQuestEventCount; i++) {
+				String distantQuestEventId = readString(in);
+				gameState.addDistantQuestEvent( distantQuestEventId );
+			}
+
+			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
 
 			boolean shipNearby = readBool(in);
 			if ( shipNearby ) {
@@ -384,6 +390,7 @@ public class SavedGameParser extends DatParser {
 		private ArrayList<Boolean> sectorList = new ArrayList<Boolean>();
 		private ArrayList<BeaconState> beaconList = new ArrayList<BeaconState>();
 		private LinkedHashMap<String, Integer> questEventMap = new LinkedHashMap<String, Integer>();
+		private ArrayList<String> distantQuestEventList = new ArrayList<String>();
 		private ShipState nearbyShipState = null;
 		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
@@ -461,6 +468,10 @@ public class SavedGameParser extends DatParser {
 			questEventMap.put( questEventId, new Integer(questBeaconId) );
 		}
 
+		public void addDistantQuestEvent( String questEventId ) {
+			distantQuestEventList.add( questEventId );
+		}
+
 		public void setNearbyShipState( ShipState shipState ) {
 			this.nearbyShipState = shipState;
 		}
@@ -506,7 +517,7 @@ public class SavedGameParser extends DatParser {
 			result.append("\nSector Beacons...\n");
 			int beaconId = 0;
 			first = true;
-			for( BeaconState beacon: beaconList ) {
+			for( BeaconState beacon : beaconList ) {
 				if (first) { first = false; }
 				else { result.append(",\n"); }
 				result.append( String.format("BeaconId: %2d\n", beaconId++) );
@@ -518,6 +529,11 @@ public class SavedGameParser extends DatParser {
 				String questEventId = entry.getKey();
 				int questBeaconId = entry.getValue().intValue();
 				result.append(String.format("QuestEventId: %s, BeaconId: %d\n", questEventId, questBeaconId));
+			}
+
+			result.append("\nNext Sector Quests...\n");
+			for (String questEventId : distantQuestEventList) {
+				result.append(String.format("QuestEventId: %s\n", questEventId));
 			}
 
 			result.append("\nNearby Ship...\n");

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -74,8 +74,10 @@ public class SavedGameParser extends DatParser {
 			for (int i=0; i < sectorCount; i++) {
 				gameState.addSector( readBool(in) );
 			}
-			
-			gameState.addMysteryBytes( new MysteryBytes(in, 8) );
+
+			int zeroBasedSectorNumber = readInt( in );  // Redundant.
+
+			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
 			
 			int beaconCount = readInt(in);
 			for (int i=0; i < beaconCount; i++) {

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -283,11 +283,11 @@ public class SavedGameParser extends DatParser {
 		DroneState drone = new DroneState( readString(in) );
 		drone.setArmed( readInt(in) );
 		drone.setAlpha( readInt(in) );
-		drone.setBeta( readInt(in) );
-		drone.setGamma( readInt(in) );
+		drone.setX( readInt(in) );
+		drone.setY( readInt(in) );
 		drone.setDelta( readInt(in) );
 		drone.setEpsilon( readInt(in) );
-		drone.setDigamma( readInt(in) );
+		drone.setHealth( readInt(in) );
 		return drone;
 	}
 
@@ -1050,33 +1050,35 @@ public class SavedGameParser extends DatParser {
 	public class DroneState {
 		private String droneId;
 		private int armed;
-		private int unknownAlpha, unknownBeta, unknownGamma, unknownDelta;
-		private int unknownEpsilon, unknownDigamma;
+		private int x = -1, y = -1;  // -1 when not armed.
+		private int health = 1;
+
+		private int unknownAlpha;
+		private int unknownDelta, unknownEpsilon;  // -1 when not armed.
 
 		public DroneState( String droneId ) {
 			this.droneId = droneId;
 		}
 
 		public void setArmed( int n ) { armed = n; }
+		public void setX( int n ) { x = n; }
+		public void setY( int n ) { y = n; }
+		public void setHealth( int n ) { health = n; }
 		public void setAlpha( int n ) { unknownAlpha = n; }
-		public void setBeta( int n ) { unknownBeta = n; }
-		public void setGamma( int n ) { unknownGamma = n; }
 		public void setDelta( int n ) { unknownDelta = n; }
 		public void setEpsilon( int n ) { unknownEpsilon = n; }
-		public void setDigamma( int n ) { unknownDigamma = n; }
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
-			result.append(String.format("DroneId: %s\n", droneId));
-			result.append(String.format("Armed:   %3d\n", armed));
+			result.append(String.format("DroneId:  %s\n", droneId));
+			result.append(String.format("Armed:    %3d\n", armed));
+			result.append(String.format("Health:   %3d\n", health));
+			result.append(String.format("Position: (%3d,%3d)\n", x, y));
 			result.append("/ / / Unknowns / / /\n");
 			result.append(String.format("Alpha:   %3d\n", unknownAlpha));
-			result.append(String.format("Beta:    %3d\n", unknownBeta));
-			result.append(String.format("Gamma:   %3d\n", unknownGamma));
 			result.append(String.format("Delta:   %3d\n", unknownDelta));
 			result.append(String.format("Epsilon: %3d\n", unknownEpsilon));
-			result.append(String.format("Digamma: %3d\n", unknownDigamma));
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -104,7 +104,9 @@ public class SavedGameParser extends DatParser {
 			}
 
 			int bytesRemaining = (int)(in.getChannel().size() - in.getChannel().position());
-			gameState.addMysteryBytes( new MysteryBytes(in, bytesRemaining) );
+			if ( bytesRemaining > 0 ) {
+				gameState.addMysteryBytes( new MysteryBytes(in, bytesRemaining) );
+			}
 
 			return gameState;  // The finally block will still be executed.
 

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -234,11 +234,11 @@ public class SavedGameParser extends DatParser {
 		crew.setRepairSkill( readInt(in) );
 		crew.setCombatSkill( readInt(in) );
 		crew.setGender( readInt(in) );
-		crew.setEta( readInt(in) );          // Matches repair?
-		crew.setTheta( readInt(in) );
-		crew.setKappa( readInt(in) );
+		crew.setRepairs( readInt(in) );
+		crew.setCombatKills( readInt(in) );
+		crew.setPilotedEvasions( readInt(in) );
 		crew.setJumpsSurvived( readInt(in) );
-		crew.setIota( readInt(in) );         // Increments to 1 at first mastery?
+		crew.setSkillMasteries( readInt(in) );
 		return crew;
 	}
 
@@ -873,13 +873,12 @@ public class SavedGameParser extends DatParser {
 		private boolean playerControlled;
 		private int pilotSkill, engineSkill, shieldSkill;
 		private int weaponSkill, repairSkill, combatSkill;
-		private int jumpsSurvived;
+		private int repairs, combatKills, pilotedEvasions;
+		private int jumpsSurvived, skillMasteries;
 		private int x, y;
 		private int gender;  // 1=Male, 0=Female.
 
 		private int unknownAlpha;
-		private int unknownEpsilon, unknownDigamma, unknownEta;
-		private int unknownTheta, unknownKappa, unknownIota;
 
 		public CrewState() {
 		}
@@ -887,6 +886,8 @@ public class SavedGameParser extends DatParser {
 		public void setName( String s ) {name = s; }
 		public void setRace( String s ) {race = s; }
 		public void setHealth( int n ) {health = n; }
+		public void setX( int x ) { this.x = x; };
+		public void setY( int y ) { this.y = y; };
 		public void setRoomId( int n ) {blueprintRoomId = n; }
 		public void setRoomSquare( int n ) { roomSquare = n; }
 		public void setPlayerControlled( boolean b ) { playerControlled = b; }
@@ -896,42 +897,39 @@ public class SavedGameParser extends DatParser {
 		public void setWeaponSkill( int n ) {weaponSkill = n; }
 		public void setRepairSkill( int n ) {repairSkill = n; }
 		public void setCombatSkill( int n ) {combatSkill = n; }
-		public void setJumpsSurvived( int n ) {jumpsSurvived = n; }
-		public void setX( int x ) { this.x = x; };
-		public void setY( int y ) { this.y = y; };
 		public void setGender( int gender ) { this.gender = gender; }
+		public void setRepairs( int n ) { repairs = n; }
+		public void setCombatKills( int n ) { combatKills = n; }
+		public void setPilotedEvasions( int n ) { pilotedEvasions = n; }
+		public void setJumpsSurvived( int n ) { jumpsSurvived = n; }
+		public void setSkillMasteries( int n ) { skillMasteries = n; }
 
 		public void setAlpha( int n ) { unknownAlpha = n; }
-		public void setEpsilon( int n ) { unknownEpsilon = n; }
-		public void setEta( int n ) { unknownEta = n; }
-		public void setTheta( int n ) { unknownTheta = n; }
-		public void setKappa( int n ) { unknownKappa = n; }
-		public void setIota( int n ) { unknownIota = n; }
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
 			result.append(String.format("Name: %s\n", name));
 			result.append(String.format("Race: %s\n", race));
+			result.append(String.format("Gender:           %s\n", (gender == 1 ? "Male" : "Female") ));
 			result.append(String.format("Health:           %3d\n", health));
 			result.append(String.format("RoomId:           %3d\n", blueprintRoomId));
 			result.append(String.format("Room Square:      %3d\n", roomSquare));
 			result.append(String.format("Player Controlled: %b\n", playerControlled));
+			result.append(String.format("Position:         %3d,%3d\n", x, y));
 			result.append(String.format("Pilot Skill:      %3d (Mastery Interval: %2d)\n", pilotSkill, MASTERY_INTERVAL_PILOT));
 			result.append(String.format("Engine Skill:     %3d (Mastery Interval: %2d)\n", engineSkill, MASTERY_INTERVAL_ENGINE));
 			result.append(String.format("Shield Skill:     %3d (Mastery Interval: %2d)\n", shieldSkill, MASTERY_INTERVAL_SHIELD));
 			result.append(String.format("Weapon Skill:     %3d (Mastery Interval: %2d)\n", weaponSkill, MASTERY_INTERVAL_WEAPON));
 			result.append(String.format("Repair Skill:     %3d (Mastery Interval: %2d)\n", repairSkill, MASTERY_INTERVAL_REPAIR));
 			result.append(String.format("Combat Skill:     %3d (Mastery Interval: %2d)\n", combatSkill, MASTERY_INTERVAL_COMBAT));
+			result.append(String.format("Repairs:          %3d\n", repairs));
+			result.append(String.format("Combat Kills:     %3d\n", combatKills));
+			result.append(String.format("Piloted Evasions: %3d\n", pilotedEvasions));
 			result.append(String.format("Jumps Survived:   %3d\n", jumpsSurvived));
-			result.append(String.format("Position:         %3d,%3d\n", x, y));
-			result.append(String.format("Gender:           %s\n", (gender == 1 ? "Male" : "Female") ));
+			result.append(String.format("Skill Masteries:  %3d\n", skillMasteries));
 			result.append("/ / / Unknowns / / /\n");
 			result.append(String.format("Alpha:            %3d\n", unknownAlpha));
-			result.append(String.format("Eta:              %3d\n", unknownEta));
-			result.append(String.format("Theta:            %3d\n", unknownTheta));
-			result.append(String.format("Kappa:            %3d\n", unknownKappa));
-			result.append(String.format("Iota:             %3d\n", unknownIota));
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -497,7 +497,7 @@ public class SavedGameParser extends DatParser {
 
 			result.append("\nState Vars...\n");
 			for (Map.Entry<String, Integer> entry : stateVars.entrySet()) {
-				result.append(String.format("%s: %4d\n", entry.getKey(), entry.getValue().intValue()));
+				result.append(String.format("%16s %4d\n", entry.getKey() +":", entry.getValue().intValue()));
 			}
 
 			result.append("\nPlayer Ship...\n");

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -119,7 +119,7 @@ public class SavedGameParser extends DatParser {
 
 		String shipBlueprintId = readString(in);  // blueprints.xml / autoBlueprints.xml.
 		String shipName = readString(in);
-		String pseudoLayoutId = readString(in);   // ?
+		String shipGfxBaseName = readString(in);   // See 'img/ship/basename_*.png'.
 
 		ShipBlueprint shipBlueprint = DataManager.get().getShip(shipBlueprintId);
 		if ( shipBlueprint == null )
@@ -133,7 +133,7 @@ public class SavedGameParser extends DatParser {
 			throw new RuntimeException( String.format("Could not find layout for %s ship: %s", (playerControlled ? "player" : "non-player"), shipName) );
 
 		ShipState shipState = new ShipState(shipName, shipBlueprintId, shipLayoutId, playerControlled);
-		shipState.setPseudoLayoutId( pseudoLayoutId );
+		shipState.setShipGraphicsBaseName( shipGfxBaseName );
 
 		int startingCrewCount = readInt(in);
 		for (int i=0; i < startingCrewCount; i++) {
@@ -515,7 +515,7 @@ public class SavedGameParser extends DatParser {
 	public class ShipState {
 		private boolean playerControlled = false;
 		private String shipName, shipBlueprintId, shipLayoutId;
-		private String pseudoLayoutId;
+		private String shipGfxBaseName;
 		private ArrayList<StartingCrewState> startingCrewList = new ArrayList<StartingCrewState>();
 		private int hullAmt, fuelAmt, dronePartsAmt, missilesAmt, scrapAmt;
 		private ArrayList<CrewState> crewList = new ArrayList<CrewState>();
@@ -546,8 +546,8 @@ public class SavedGameParser extends DatParser {
 		 *
 		 * The proper shipLayoutId comes from the ShipBlueprint.
 		 */
-		public void setPseudoLayoutId( String pseudoLayoutId ) {
-			this.pseudoLayoutId = pseudoLayoutId;
+		public void setShipGraphicsBaseName( String shipGfxBaseName ) {
+			this.shipGfxBaseName = shipGfxBaseName;
 		}
 
 		public void addStartingCrewMember( StartingCrewState sc ) {
@@ -662,9 +662,10 @@ public class SavedGameParser extends DatParser {
 
 			StringBuilder result = new StringBuilder();
 			boolean first = true;
-			result.append(String.format("Ship Name:   %s\n", shipName));
-			result.append(String.format("Ship Type:   %s\n", shipBlueprintId));
-			result.append(String.format("Ship Layout: %s (Actually %s)\n", shipLayoutId, pseudoLayoutId));
+			result.append(String.format("Ship Name:    %s\n", shipName));
+			result.append(String.format("Ship Type:    %s\n", shipBlueprintId));
+			result.append(String.format("Ship Layout:  %s\n", shipLayoutId));
+			result.append(String.format("Gfx BaseName: %s\n", shipGfxBaseName));
 
 			result.append("\nSupplies...\n");
 			result.append(String.format("Hull:        %3d\n", hullAmt));

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -447,6 +447,12 @@ public class SavedGameParser extends DatParser {
 			sectorList.set( sector, new Boolean(visited) );
 		}
 
+		/**
+		 * Adds a beacon to the sector map.
+		 * Beacons are indexed top-to-bottom for each column,
+		 * left-to-right. They're randomly offset a little
+		 * when shown on screen to disguise the columns.
+		 */
 		public void addBeacon( BeaconState beacon ) {
 			beaconList.add( beacon );
 		}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -497,7 +497,7 @@ public class SavedGameParser extends DatParser {
 
 			result.append("\nState Vars...\n");
 			for (Map.Entry<String, Integer> entry : stateVars.entrySet()) {
-				result.append(String.format("%16s %4d\n", entry.getKey() +":", entry.getValue().intValue()));
+				result.append(String.format("%-16s %4d\n", entry.getKey() +":", entry.getValue().intValue()));
 			}
 
 			result.append("\nPlayer Ship...\n");

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -224,7 +224,7 @@ public class SavedGameParser extends DatParser {
 		CrewState crew = new CrewState();
 		crew.setName( readString(in) );
 		crew.setRace( readString(in) );
-		crew.setAlpha( readInt(in) );        // Always 0?
+		crew.setEnemyBoardingDrone( readBool(in) );
 		crew.setHealth( readInt(in) );
 		crew.setX( readInt(in) );
 		crew.setY( readInt(in) );
@@ -418,9 +418,9 @@ public class SavedGameParser extends DatParser {
 		 * Sets a state var.
 		 * The following ids have been seen in the wild:
 		 * blue_alien, dead_crew, destroyed_rock, env_danger, fired_shot,
-		 * killed_crew, nebula, reactor_upgrade, store_purchase, store_repair,
-		 * system_upgrade, teleported, used_drone, used_missile,
-		 * weapon_upgrade.
+		 * killed_crew, nebula, offensive_drone, reactor_upgrade,
+		 * store_purchase, store_repair, system_upgrade, teleported,
+		 * used_drone, used_missile, weapon_upgrade.
 		 *
 		 * Each is optional, and counts something.
 		 * *_upgrade counts upgrades beyond the ship's default levels.
@@ -858,6 +858,7 @@ public class SavedGameParser extends DatParser {
 		// Zoltan-produced power is not stored in SystemState.
 
 		private String name, race;
+		private boolean enemyBoardingDrone = false;
 		private int health;
 		private int blueprintRoomId;
 		private int roomSquare;  // 0-based, L-to-R wrapped row.
@@ -895,32 +896,41 @@ public class SavedGameParser extends DatParser {
 		public void setJumpsSurvived( int n ) { jumpsSurvived = n; }
 		public void setSkillMasteries( int n ) { skillMasteries = n; }
 
-		public void setAlpha( int n ) { unknownAlpha = n; }
+		/**
+		 * Sets whether this crew member is a hostile drone.
+		 * Bizarrely, this trumps race and playerControlled.
+		 *
+		 * Presumably this is so intruders can persist without
+		 * a ship, which would normally have a drones section
+		 * to contain them.
+		 */
+		public void setEnemyBoardingDrone( boolean b ) {
+			enemyBoardingDrone = b;
+		}
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
-			result.append(String.format("Name: %s\n", name));
-			result.append(String.format("Race: %s\n", race));
-			result.append(String.format("Gender:           %s\n", (gender == 1 ? "Male" : "Female") ));
-			result.append(String.format("Health:           %3d\n", health));
-			result.append(String.format("RoomId:           %3d\n", blueprintRoomId));
-			result.append(String.format("Room Square:      %3d\n", roomSquare));
+			result.append(String.format("Name:              %s\n", name));
+			result.append(String.format("Race:              %s\n", race));
+			result.append(String.format("Enemy Drone:       %b\n", enemyBoardingDrone));
+			result.append(String.format("Gender:            %s\n", (gender == 1 ? "Male" : "Female") ));
+			result.append(String.format("Health:            %3d\n", health));
+			result.append(String.format("RoomId:            %3d\n", blueprintRoomId));
+			result.append(String.format("Room Square:       %3d\n", roomSquare));
 			result.append(String.format("Player Controlled: %b\n", playerControlled));
-			result.append(String.format("Position:         %3d,%3d\n", x, y));
-			result.append(String.format("Pilot Skill:      %3d (Mastery Interval: %2d)\n", pilotSkill, MASTERY_INTERVAL_PILOT));
-			result.append(String.format("Engine Skill:     %3d (Mastery Interval: %2d)\n", engineSkill, MASTERY_INTERVAL_ENGINE));
-			result.append(String.format("Shield Skill:     %3d (Mastery Interval: %2d)\n", shieldSkill, MASTERY_INTERVAL_SHIELD));
-			result.append(String.format("Weapon Skill:     %3d (Mastery Interval: %2d)\n", weaponSkill, MASTERY_INTERVAL_WEAPON));
-			result.append(String.format("Repair Skill:     %3d (Mastery Interval: %2d)\n", repairSkill, MASTERY_INTERVAL_REPAIR));
-			result.append(String.format("Combat Skill:     %3d (Mastery Interval: %2d)\n", combatSkill, MASTERY_INTERVAL_COMBAT));
-			result.append(String.format("Repairs:          %3d\n", repairs));
-			result.append(String.format("Combat Kills:     %3d\n", combatKills));
-			result.append(String.format("Piloted Evasions: %3d\n", pilotedEvasions));
-			result.append(String.format("Jumps Survived:   %3d\n", jumpsSurvived));
-			result.append(String.format("Skill Masteries:  %3d\n", skillMasteries));
-			result.append("/ / / Unknowns / / /\n");
-			result.append(String.format("Alpha:            %3d\n", unknownAlpha));
+			result.append(String.format("Position:          %3d,%3d\n", x, y));
+			result.append(String.format("Pilot Skill:       %3d (Mastery Interval: %2d)\n", pilotSkill, MASTERY_INTERVAL_PILOT));
+			result.append(String.format("Engine Skill:      %3d (Mastery Interval: %2d)\n", engineSkill, MASTERY_INTERVAL_ENGINE));
+			result.append(String.format("Shield Skill:      %3d (Mastery Interval: %2d)\n", shieldSkill, MASTERY_INTERVAL_SHIELD));
+			result.append(String.format("Weapon Skill:      %3d (Mastery Interval: %2d)\n", weaponSkill, MASTERY_INTERVAL_WEAPON));
+			result.append(String.format("Repair Skill:      %3d (Mastery Interval: %2d)\n", repairSkill, MASTERY_INTERVAL_REPAIR));
+			result.append(String.format("Combat Skill:      %3d (Mastery Interval: %2d)\n", combatSkill, MASTERY_INTERVAL_COMBAT));
+			result.append(String.format("Repairs:           %3d\n", repairs));
+			result.append(String.format("Combat Kills:      %3d\n", combatKills));
+			result.append(String.format("Piloted Evasions:  %3d\n", pilotedEvasions));
+			result.append(String.format("Jumps Survived:    %3d\n", jumpsSurvived));
+			result.append(String.format("Skill Masteries:   %3d\n", skillMasteries));
 			return result.toString();
 		}
 	}
@@ -956,10 +966,10 @@ public class SavedGameParser extends DatParser {
 			StringBuilder result = new StringBuilder();
 			if (capacity > 0) {
 				result.append(String.format("%s: %d/%d Power\n", name, power, capacity));
-				result.append(String.format("Damaged Bars:    %d\n", damagedBars));
-				result.append(String.format("Ionized Bars:    %d\n", ionizedBars));
-				result.append(String.format("Repair Progress: %d%%\n", repairProgress));
-				result.append(String.format("Burn Progress:   %d%%\n", burnProgress));
+				result.append(String.format("Damaged Bars:    %3d\n", damagedBars));
+				result.append(String.format("Ionized Bars:    %3d\n", ionizedBars));
+				result.append(String.format("Repair Progress: %3d%%\n", repairProgress));
+				result.append(String.format("Burn Progress:   %3d%%\n", burnProgress));
 				result.append("/ / / Unknowns / / /\n");
 				if ( mysteryList.size() > 0 ) {
 					result.append("Mystery Bytes...\n");
@@ -1055,7 +1065,7 @@ public class SavedGameParser extends DatParser {
 
 			result.append(String.format("WeaponId:       %s\n", weaponId));
 			result.append(String.format("Armed:          %b\n", armed));
-			result.append(String.format("Cooldown Ticks: %d (max: %s)\n", cooldownTicks, cooldownString));
+			result.append(String.format("Cooldown Ticks: %2d (max: %-2s)\n", cooldownTicks, cooldownString));
 			return result.toString();
 		}
 	}
@@ -1132,7 +1142,7 @@ public class SavedGameParser extends DatParser {
 				result.append(String.format("Bkg Starscape:     %s\n", bgStarscapeImageInnerPath));
 				result.append(String.format("Bkg Sprite:        %s\n", bgSpriteImageInnerPath));
 				result.append(String.format("Bkg Sprite Coords: %3d,%3d\n", bgSpritePosX, bgSpritePosY));
-				result.append(String.format("Unknown:           %d\n", unknownVisitedAlpha));
+				result.append(String.format("Unknown:           %3d\n", unknownVisitedAlpha));
 			}
 			
 			result.append(String.format("Seen:              %b\n", seen));
@@ -1141,7 +1151,7 @@ public class SavedGameParser extends DatParser {
 			if ( enemyPresent ) {
 				result.append(String.format("  Ship Event ID:          %s\n", shipEventId));
 				result.append(String.format("  Ship Blueprint List ID: %s\n", shipBlueprintListId));
-				result.append(String.format("  Unknown:                %d\n", unknownEnemyPresentAlpha));
+				result.append(String.format("  Unknown:                %5d\n", unknownEnemyPresentAlpha));
 			}
 			
 			result.append(String.format("Fleets Present:    %s\n", fleetPresence));

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -37,8 +37,12 @@ public class SavedGameParser extends DatParser {
 			SavedGameState gameState = new SavedGameState();
 			in = new FileInputStream(datFile);
 
-			// Mystery bytes x24
-			gameState.addMysteryBytes( new MysteryBytes(in, 24) );
+			gameState.addMysteryBytes( new MysteryBytes(in, 8) );
+
+			gameState.setTotalShipsDefeated( readInt(in) );
+			gameState.setTotalBeaconsExplored( readInt(in) );
+			gameState.setTotalScrapCollected( readInt(in) );
+			gameState.setTotalCrewHired( readInt(in) );
 
 			String playerShipName = readString(in);         // Redundant.
 			String playerShipBlueprintId = readString(in);  // Redundant.
@@ -373,6 +377,7 @@ public class SavedGameParser extends DatParser {
 	// Stash state classes here until they're finalized.
 
 	public class SavedGameState {
+		private int totalShipsDefeated, totalBeaconsExplored, totalScrapCollected, totalCrewHired;
 		private String playerShipName = "";
 		private String playerShipBlueprintId = "";
 		private int sectorNumber = 1;
@@ -392,7 +397,8 @@ public class SavedGameParser extends DatParser {
 		 * The following ids have been seen in the wild:
 		 * blue_alien, dead_crew, destroyed_rock, env_danger, fired_shot,
 		 * killed_crew, nebula, reactor_upgrade, store_purchase, store_repair,
-		 * system_upgrade, teleported, used_missile, weapon_upgrade.
+		 * system_upgrade, teleported, used_drone, used_missile,
+		 * weapon_upgrade.
 		 *
 		 * Each is optional, and counts something.
 		 * *_upgrade counts upgrades beyond the ship's default levels.
@@ -411,6 +417,11 @@ public class SavedGameParser extends DatParser {
 			Integer result = stateVars.get(stateVarId);
 			return result.intValue();
 		}
+
+		public void setTotalShipsDefeated( int n ) { totalShipsDefeated = n; }
+		public void setTotalBeaconsExplored( int n ) { totalBeaconsExplored = n; }
+		public void setTotalScrapCollected( int n ) { totalScrapCollected = n; }
+		public void setTotalCrewHired( int n ) { totalCrewHired = n; }
 
 		/**
 		 * Set redundant player ship info.
@@ -446,7 +457,11 @@ public class SavedGameParser extends DatParser {
 			boolean first = true;
 			result.append(String.format("Ship Name: %s\n", playerShipName));
 			result.append(String.format("Ship Type: %s\n", playerShipBlueprintId));
-			result.append(String.format("Sector: %d\n", sectorNumber));
+			result.append(String.format("Sector:                 %4d\n", sectorNumber));
+			result.append(String.format("Total Ships Defeated:   %4d\n", totalShipsDefeated));
+			result.append(String.format("Total Beacons Explored: %4d\n", totalBeaconsExplored));
+			result.append(String.format("Total Scrap Collected:  %4d\n", totalScrapCollected));
+			result.append(String.format("Total Crew Hired:       %4d\n", totalCrewHired));
 
 			result.append("\nState Vars...\n");
 			for (Map.Entry<String, Integer> entry : stateVars.entrySet()) {
@@ -675,7 +690,8 @@ public class SavedGameParser extends DatParser {
 			}
 
 			result.append("\nSystems...\n");
-			first = true;
+			result.append(String.format("  Reserve Power Capacity: %2d\n", reservePowerCapacity));
+			first = false;
 			for (SystemState s : systemList) {
 				if (first) { first = false; }
 				else { result.append(",\n"); }

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -578,7 +578,6 @@ public class SavedGameParser extends DatParser {
 		private ArrayList<DroneState> droneList = new ArrayList<DroneState>();
 		private ArrayList<String> augmentIdList = new ArrayList<String>();
 		private ArrayList<String> cargoIdList = new ArrayList<String>();
-		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
 		public ShipState(String shipName, String shipBlueprintId, String shipLayoutId, boolean playerControlled) {
 			this.shipName = shipName;
@@ -665,10 +664,6 @@ public class SavedGameParser extends DatParser {
 		
 		public void addCargoItemId( String cargoItemId ) {
 			cargoIdList.add( cargoItemId );
-		}
-		
-		public void addMysteryBytes( MysteryBytes m ) {
-			mysteryList.add(m);
 		}
 
 		@Override
@@ -814,14 +809,6 @@ public class SavedGameParser extends DatParser {
 			result.append("\nCargo...\n");
 			for (String cargoItemId : cargoIdList) {
 				result.append(String.format("CargoItemId: %s\n", cargoItemId));
-			}
-
-			result.append("\nMystery Bytes...\n");
-			first = true;
-			for (MysteryBytes m : mysteryList) {
-				if (first) { first = false; }
-				else { result.append(",\n"); }
-				result.append(m.toString().replaceAll("(^|\n)(.+)", "$1  $2"));
 			}
 
 			return result.toString();

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -277,9 +277,9 @@ public class SavedGameParser extends DatParser {
 	}
 
 	private DoorState readDoor( InputStream in ) throws IOException {
-		int alpha = readInt(in);  // 0. What else would a door have; damage?
 		int open = readInt(in);   // 0=Closed, 1=Open
-		DoorState door = new DoorState( alpha, open );
+		int alpha = readInt(in);  // 0. What else would a door have; damage?
+		DoorState door = new DoorState( open, alpha );
 		return door;
 	}
 
@@ -981,9 +981,9 @@ public class SavedGameParser extends DatParser {
 
 		private int unknownAlpha;
 
-		public DoorState( int alpha, int open ) {
-			this.unknownAlpha = alpha;
+		public DoorState( int open, int alpha ) {
 			this.open = open;
+			this.unknownAlpha = alpha;
 		}
 
 		@Override

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -95,7 +95,7 @@ public class SavedGameParser extends DatParser {
 				gameState.addDistantQuestEvent( distantQuestEventId );
 			}
 
-			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
+			gameState.setCurrentBeaconId( readInt(in) );
 
 			boolean shipNearby = readBool(in);
 			if ( shipNearby ) {
@@ -393,6 +393,7 @@ public class SavedGameParser extends DatParser {
 		private ArrayList<String> distantQuestEventList = new ArrayList<String>();
 		private ShipState nearbyShipState = null;
 		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
+		private int currentBeaconId = 0;  // Where the player is.
 
 		public void setTotalShipsDefeated( int n ) { totalShipsDefeated = n; }
 		public void setTotalBeaconsExplored( int n ) { totalBeaconsExplored = n; }
@@ -472,6 +473,8 @@ public class SavedGameParser extends DatParser {
 			distantQuestEventList.add( questEventId );
 		}
 
+		public void setCurrentBeaconId( int n ) { currentBeaconId = n; }
+
 		public void setNearbyShipState( ShipState shipState ) {
 			this.nearbyShipState = shipState;
 		}
@@ -494,7 +497,7 @@ public class SavedGameParser extends DatParser {
 
 			result.append("\nState Vars...\n");
 			for (Map.Entry<String, Integer> entry : stateVars.entrySet()) {
-				result.append(String.format("%s: %d\n", entry.getKey(), entry.getValue().intValue()));
+				result.append(String.format("%s: %4d\n", entry.getKey(), entry.getValue().intValue()));
 			}
 
 			result.append("\nPlayer Ship...\n");
@@ -502,8 +505,9 @@ public class SavedGameParser extends DatParser {
 				result.append(playerShipState.toString().replaceAll("(^|\n)(.+)", "$1  $2"));
 
 			result.append("\nSector Data...\n");
-			result.append( String.format("Sector Layout Seed: %d\n", sectorLayoutSeed) );
-			result.append( String.format("Rebel Fleet Offset: %d\n", rebelFleetOffset) );
+			result.append( String.format("Sector Layout Seed: %5d\n", sectorLayoutSeed) );
+			result.append( String.format("Rebel Fleet Offset: %5d\n", rebelFleetOffset) );
+			result.append( String.format("Current BeaconId:   %5d\n", currentBeaconId) );
 
 			result.append("\nSector Tree Breadcrumbs...\n");
 			first = true;


### PR DESCRIPTION
SavedGameState
- totalShipsDefeated
- totalBeaconsExplored
- totalScrapCollected
- totalCrewHired
- currentBeaconId
- next-sector quest events
- 'Mystery Int List' became 'Sector Tree Breadcrumbs'. Each sector you jump to, in the colored dot tree, becomes True, indexed top-to-bottom for each column.
- Added comment describing how beacons are indexed within a sector.

ShipState
- pseudoLayoutId became shipGfxBaseName

CrewState
- enemyBoardingDrone
- repairs
- combatKills
- pilotedEvasions
- skillMasteries

DoorState
- Fixed Open/Alpha that were swapped.

DroneState
- playerControlled
- (x, y)
- blueprintRoomId
- roomSquare
- health
