### PR TITLE
Flagship, Breaches mk II, and Sector Stuff

### DIFF
--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -943,9 +943,6 @@ public class SavedGameParser extends DatParser {
 
 
 	public class SystemState {
-		// miscTicks isn't fully understood.
-		//   It sometimes has huge positive and negative values.
-
 		private String name;
 		private int capacity = 0;
 		private int power = 0;
@@ -958,27 +955,20 @@ public class SavedGameParser extends DatParser {
 		// ionizedBars may briefly be -1 initially when a system
 		// disables itself. Then ionizedBars will be set to capacity+1.
 
-		// miscTicks is reset to 0 upon loading.
+		// miscTicks is reset upon loading.
 		// Whatever needs timing will respond to it as it increments,
 		// including resetting after intervals. If nothing needs it,
 		// it may be 0, or more often, MIN_INT (signed 32bit \x0000_0080)
-		// of the compiler that built FTL. The parser will translate that
+		// of the compiler that built FTL. This parser will translate that
 		// to Java's equivalent minimum during reading, and back during
 		// writing.
 		//   Deionization: each bar counts to 5000.
-		//   Fire: (hull damage / ignition inc)?, ???
-		//   Shield bubbling: ???
-		//   Engines: FTL charging, ???
-		//   Oxygen: refill, ???
-		//   Cloaking: cooldown, ???
-		//   Teleporter: cooldown, ???
-		//   Doors: closing busted down doors?, ???
-		//   Pilot: ???, ???
-		//   Weapons: incrementing cooldownTicks?, ???
-		//   Medbay: healing?, ???
-		// These probably tick, but I havent checked...
-		//   Artillery: cooldown?, ???
-		//   Drone Ctrl: (healing / shots)?, ???
+		//
+		// TODO:
+		// Nearly every system has been observed with non-zero values,
+		// but aside from Teleporter/Cloaking, normal use doesn't reliably
+		// set such values. Might be unspecified garbage when not actively
+		// counting. Sometimes has huge positive and negative values.
 
 		public SystemState( String name ) {
 			this.name = name;

--- a/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
@@ -214,7 +214,29 @@ public class ShipBlueprint {
 		public void setArtilleryRooms(List<SystemRoom> artilleryRooms) {
 			this.artilleryRooms = artilleryRooms;
 		}
-		
+
+		/**
+		 * Returns the system's name in a given room, or null.
+		 */
+		public String getSystemNameByRoomId( int roomId ) {
+			if ( getPilotRoom() != null && getPilotRoom().getRoomId() == roomId ) return "Pilot";
+			if ( getDoorsRoom() != null && getDoorsRoom().getRoomId() == roomId ) return "Doors";
+			if ( getSensorsRoom() != null && getSensorsRoom().getRoomId() == roomId ) return "Sensors";
+			if ( getMedicalRoom() != null && getMedicalRoom().getRoomId() == roomId ) return "Medbay";
+			if ( getLifeSupportRoom() != null && getLifeSupportRoom().getRoomId() == roomId ) return "Oxygen";
+			if ( getShieldRoom() != null && getShieldRoom().getRoomId() == roomId ) return "Shields";
+			if ( getEngineRoom() != null && getEngineRoom().getRoomId() == roomId ) return "Engines";
+			if ( getWeaponRoom() != null && getWeaponRoom().getRoomId() == roomId ) return "Weapons";
+			if ( getDroneRoom() != null && getDroneRoom().getRoomId() == roomId ) return "Drone Ctrl";
+			if ( getTeleporterRoom() != null && getTeleporterRoom().getRoomId() == roomId ) return "Teleporter";
+			if ( getCloakRoom() != null && getCloakRoom().getRoomId() == roomId ) return "Cloaking";
+			if ( getArtilleryRooms() != null ) {
+				for ( SystemRoom artilleryRoom : artilleryRooms ) {
+					if ( artilleryRoom.getRoomId() == roomId ) return "Artillery";
+				}
+			}
+			return null;
+		}
 	}
 
 	public String getId() {


### PR DESCRIPTION
SavedGameState
- rebelPursuitMod - Delay / alert the rebel fleet with negative / positive values.
- sectorHazardsVisible
- rebelFlagshipVisible - Instant loss if not sector 8. :P
- rebelFlagshipHop - Nth beaconId it plans to jump to.
- rebelFlagshipApproaching (as opposed to orbiting its beacon)
- warningLights is now breaches - I originally misunderstood their coordinate attributes. They're 0-based Nth floor-square (not corner) from the top-left, and also minus the ShipLayout's X_OFFSET / Y_OFFSET.

SystemState
- miscTicks - Definitely milliseconds of de-ionization, but often has non-0, non-MIN_INT values in ordinary systems. Possibly unintended garbage when not actively ticking... All its outlandish values are shown for now.

RebelFlagshipState
- pendingStage
- last seen occupancy - For preserving boss crew count between stages.
