### PR TITLE
Basic Saved Game Editing Has Arrived

### DIFF
--- a/src/main/java/net/blerf/ftl/model/ShipLayout.java
+++ b/src/main/java/net/blerf/ftl/model/ShipLayout.java
@@ -99,6 +99,12 @@ public class ShipLayout {
 		return doorMap.size();
 	}
 
+	/**
+	 * Returns the map containing this layout's door info.
+	 *
+	 * Keys are in the order of the original layout config file.
+	 * That is NOT the same order as doors in saved games.
+	 */
 	public LinkedHashMap<DoorCoordinate, EnumMap<DoorInfo,Integer>> getDoorMap() {
 		return doorMap;
 	}

--- a/src/main/java/net/blerf/ftl/model/ShipLayout.java
+++ b/src/main/java/net/blerf/ftl/model/ShipLayout.java
@@ -11,7 +11,7 @@ import java.util.NoSuchElementException;
 public class ShipLayout {
 	// TODO: Some ROOM values haven't been deciphered (see: setRoom()).
 
-	public enum RoomInfo { ALPHA, BETA, SQUARES_H, SQUARES_V }
+	public enum RoomInfo { LOCATION_X, LOCATION_Y, SQUARES_H, SQUARES_V }
 	public enum DoorInfo { ROOM_ID_A, ROOM_ID_B }
 
 	private int offsetX = 0, offsetY = 0, horizontal = 0, vertical = 0;
@@ -43,16 +43,16 @@ public class ShipLayout {
 	 * Sets a room's info.
 	 *
 	 * @param roomId a roomId
-	 * @param alpha ???
-	 * @param beta ???
+	 * @param locationX 0-based Nth square from the left (without layout offset)
+	 * @param locationY 0-based Nth square from the top (without layout offset)
 	 * @param squaresH horizontal count of tiles
 	 * @param squaresV certical count of tiles
 	 */
-	public void setRoom( int roomId, int alpha, int beta, int squaresH, int squaresV ) {
+	public void setRoom( int roomId, int locationX, int locationY, int squaresH, int squaresV ) {
 		Integer roomIdObj = new Integer(roomId);
 		EnumMap<RoomInfo,Integer> infoMap = new EnumMap<RoomInfo,Integer>(RoomInfo.class);
-		infoMap.put( RoomInfo.ALPHA, new Integer(alpha) );
-		infoMap.put( RoomInfo.BETA, new Integer(beta) );
+		infoMap.put( RoomInfo.LOCATION_X, new Integer(locationX) );
+		infoMap.put( RoomInfo.LOCATION_Y, new Integer(locationY) );
 		infoMap.put( RoomInfo.SQUARES_H, new Integer(squaresH) );
 		infoMap.put( RoomInfo.SQUARES_V, new Integer(squaresV) );
 		roomMap.put( roomIdObj, infoMap );

--- a/src/main/java/net/blerf/ftl/parser/DataManager.java
+++ b/src/main/java/net/blerf/ftl/parser/DataManager.java
@@ -16,6 +16,7 @@ import net.blerf.ftl.model.ShipLayout;
 import net.blerf.ftl.xml.Achievement;
 import net.blerf.ftl.xml.Blueprints;
 import net.blerf.ftl.xml.ShipBlueprint;
+import net.blerf.ftl.xml.ShipChassis;
 import net.blerf.ftl.xml.WeaponBlueprint;
 
 import org.apache.logging.log4j.LogManager;
@@ -46,6 +47,7 @@ public class DataManager implements Closeable {
 	private List<ShipBlueprint> playerShips; // Type A's
 	private Map<ShipBlueprint, List<Achievement>> shipAchievements;
 	private Map<String, ShipLayout> shipLayouts;
+	private Map<String, ShipChassis> shipChassisMap;
 	
 	private	MappedDatParser dataParser = null;
 	private	MappedDatParser resourceParser = null;
@@ -112,8 +114,9 @@ public class DataManager implements Closeable {
 				shipAchievements.put( ship, shipAchs );
 			}
 
-			// This'll populate as layouts are requested.
+			// These'll populate as files are requested.
 			shipLayouts = new HashMap<String, ShipLayout>();
+			shipChassisMap = new HashMap<String, ShipChassis>();
 
 		} catch (JAXBException e) {
 			meltdown = true;
@@ -209,6 +212,34 @@ public class DataManager implements Closeable {
 
 			} catch (IOException e) {
 				log.error( "An error occurred while parsing ShipLayout: "+ id, e );
+
+			} finally {
+				try {if (in != null) in.close();}
+				catch (IOException f) {}
+			}
+		}
+
+		return result;
+	}
+
+	public ShipChassis getShipChassis(String id) {
+		ShipChassis result = shipChassisMap.get(id);
+
+		if ( result == null ) {  // Wasn't cached; try parsing it.
+			InputStream in = null;
+			try {
+				in = getDataInputStream("data/"+ id +".xml");
+				result = dataParser.readChassis(in);
+				shipChassisMap.put( id, result );
+
+			} catch (JAXBException e) {
+				log.error( "Parsing XML failed for ShipChassis id: "+ id );
+
+			} catch (FileNotFoundException e) {
+				log.error( "No ShipChassis found for id: "+ id );
+
+			} catch (IOException e) {
+				log.error( "An error occurred while parsing ShipChassis: "+ id, e );
 
 			} finally {
 				try {if (in != null) in.close();}

--- a/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
+++ b/src/main/java/net/blerf/ftl/parser/MappedDatParser.java
@@ -32,6 +32,7 @@ import net.blerf.ftl.xml.Achievement;
 import net.blerf.ftl.xml.Achievements;
 import net.blerf.ftl.xml.Blueprints;
 import net.blerf.ftl.xml.ShipBlueprint;
+import net.blerf.ftl.xml.ShipChassis;
 
 
 public class MappedDatParser extends Parser implements Closeable {
@@ -221,6 +222,42 @@ public class MappedDatParser extends Parser implements Closeable {
 			}
 		}
 		return shipLayout;
+	}
+
+	public ShipChassis readChassis(InputStream stream) throws IOException, JAXBException {
+		log.trace("Reading ship chassis XML");
+
+		// Need to clean invalid XML and comments before JAXB parsing
+
+		BufferedReader in = new BufferedReader(new InputStreamReader(stream, "UTF8"));
+		StringBuilder sb = new StringBuilder();
+		String line;
+
+		boolean comment = false;
+		while( (line = in.readLine()) != null ) {
+			line = line.replaceAll("<!--.*-->", "");
+			line = line.replaceAll("<(/?)gib[0-9]*>", "<$1gib>");
+
+			// Remove multiline comments
+			if (comment && line.contains("-->"))
+				comment = false;
+			else if (line.contains("<!--"))
+				comment = true;
+			else if (!comment)
+				sb.append(line).append("\n");
+		}
+		in.close();
+		if ( sb.substring(0, BOM_UTF8.length()).equals(BOM_UTF8) )
+			sb.replace(0, BOM_UTF8.length(), "");
+
+		// XML has multiple root nodes so need to wrap.
+		sb.insert(0, "<shipChassis>\n");
+		sb.append("</shipChassis>\n");
+
+		// Parse cleaned XML
+		ShipChassis sch = (ShipChassis)unmarshalFromSequence( ShipChassis.class, sb.toString() );
+
+		return sch;
 	}
 
 	/**

--- a/src/main/java/net/blerf/ftl/parser/Parser.java
+++ b/src/main/java/net/blerf/ftl/parser/Parser.java
@@ -24,6 +24,10 @@ public class Parser {
 		
 	}
 
+	protected void writeBool(OutputStream out, boolean b) throws IOException {
+		writeInt(out, (b ? 1 : 0) );
+	}
+
 	protected int readInt(InputStream in) throws IOException {
 		
 		int numRead = 0;

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -447,7 +447,7 @@ public class SavedGameParser extends DatParser {
 
 		int previousRoomCount = readInt(in);
 		for (int i=0; i < previousRoomCount; i++) {
-			flagship.setPreviousOccupancy( i, readBool(in) );
+			flagship.setPreviousOccupancy( i, readInt(in) );
 		}
 
 		return flagship;
@@ -1509,7 +1509,7 @@ public class SavedGameParser extends DatParser {
 	public class RebelFlagshipState {
 		private String[] shipBlueprintIds;
 		private int pendingStage = 1;
-		private LinkedHashMap<Integer, Boolean> occupancyMap = new LinkedHashMap<Integer, Boolean>();
+		private LinkedHashMap<Integer, Integer> occupancyMap = new LinkedHashMap<Integer, Integer>();
 
 		/**
 		 * Constructor.
@@ -1533,7 +1533,7 @@ public class SavedGameParser extends DatParser {
 		}
 
 		/**
-		 * Sets whether a room had a crew member in the last seen layout.
+		 * Sets whether a room had crew members in the last seen layout.
 		 *
 		 * Stage 1 sets this, but doesn't read it.
 		 * Fleeing stage 1, altering these bytes, then returning
@@ -1553,10 +1553,10 @@ public class SavedGameParser extends DatParser {
 		 * Stage 3 probably will, too. (TODO: Confirm this.)
 		 *
 		 * @param roomId a room in the last seen stage's shipLayout
-		 * @param b true if there was crew, false otherwise
+		 * @param n the number of crew in that room
 		 */
-		public void setPreviousOccupancy( int roomId, boolean b ) {
-			occupancyMap.put( new Integer(roomId), new Boolean(b) );
+		public void setPreviousOccupancy( int roomId, int n ) {
+			occupancyMap.put( new Integer(roomId), new Integer(n) );
 		}
 
 		@Override
@@ -1574,14 +1574,14 @@ public class SavedGameParser extends DatParser {
 			result.append( String.format("Pending Ship Type: %s\n", shipBlueprintIds[pendingStage-1] ) );
 
 			result.append( "\nOccupancy of Last Seen Type...\n" );
-			for (Map.Entry<Integer, Boolean> entry : occupancyMap.entrySet()) {
+			for (Map.Entry<Integer, Integer> entry : occupancyMap.entrySet()) {
 				int roomId = entry.getKey().intValue();
-				boolean b = entry.getValue().booleanValue();
+				int occupantCount = entry.getValue().intValue();
 
 				String roomName = blueprintSystems.getSystemNameByRoomId( roomId );
 				if (roomName == null) roomName = "Empty";
 
-				result.append( String.format("RoomId: %2d (%-10s), Occupied: %b\n", roomId, roomName, b) );
+				result.append( String.format("RoomId: %2d (%-10s), Crew: %d\n", roomId, roomName, occupantCount) );
 			}
 
 			return result.toString();

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -50,8 +50,10 @@ public class SavedGameParser extends DatParser {
 			gameState.setTotalCrewHired( readInt(in) );
 
 			String playerShipName = readString(in);         // Redundant.
+			gameState.setPlayerShipName( playerShipName );
+
 			String playerShipBlueprintId = readString(in);  // Redundant.
-			gameState.setPlayerShipInfo( playerShipName, playerShipBlueprintId );
+			gameState.setPlayerShipBlueprintId( playerShipBlueprintId );
 
 			int oneBasedSectorNumber = readInt(in);  // Redundant.
 
@@ -790,14 +792,16 @@ public class SavedGameParser extends DatParser {
 		public int getTotalScrapCollected() { return totalScrapCollected; }
 		public int getTotalCrewHired() { return totalCrewHired; }
 
-		/**
-		 * Set redundant player ship info.
-		 */
-		public void setPlayerShipInfo( String shipName, String shipBlueprintId ) {
+		/** Sets redundant player ship name. */
+		public void setPlayerShipName( String shipName) {
 			playerShipName = shipName;
-			playerShipBlueprintId = shipBlueprintId;
 		}
 		public String getPlayerShipName() { return playerShipName; }
+
+		/** Sets redundant player ship blueprint. */
+		public void setPlayerShipBlueprintId( String shipBlueprintId ) {
+			playerShipBlueprintId = shipBlueprintId;
+		}
 		public String getPlayerShipBlueprintId() { return playerShipBlueprintId; }
 
 		public void addCargoItemId( String cargoItemId ) {
@@ -1121,6 +1125,8 @@ public class SavedGameParser extends DatParser {
 			this.shipLayoutId = shipLayoutId;
 			this.auto = auto;
 		}
+
+		public void setShipName( String s ) { shipName = s; }
 
 		public String getShipName() { return shipName; }
 		public String getShipBlueprintId() { return shipBlueprintId; }

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -517,7 +517,7 @@ public class SavedGameParser extends DatParser {
 		 * Modifying this will not change the sector tree.
 		 *
 		 * TODO: Determine long-term effects of this.
-		 * The Final Stand is baked into the sector tree,
+		 * The Last Stand is baked into the sector tree,
 		 * but weird things might happen at or above #7.
 		 */
 		public void setSectorNumber( int n ) { sectorNumber = n; }

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -67,7 +67,7 @@ public class SavedGameParser extends DatParser {
 			ShipState playerShipState = readShip( in, true );
 			gameState.setPlayerShipState( playerShipState );
 
-			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
+			gameState.setSectorTreeSeed( readInt(in) );
 			
 			gameState.setSectorLayoutSeed( readInt(in) );
 			
@@ -468,6 +468,7 @@ public class SavedGameParser extends DatParser {
 		private int sectorNumber = 1;
 		private HashMap<String, Integer> stateVars = new HashMap<String, Integer>();
 		private ShipState playerShipState = null;
+		private int sectorTreeSeed;
 		private int sectorLayoutSeed;
 		private int rebelFleetOffset;
 		private int rebelPursuitMod = 0;
@@ -551,6 +552,9 @@ public class SavedGameParser extends DatParser {
 			this.playerShipState = shipState;
 		}
 
+		// TODO: See what havoc can occur when seeds change.
+		// (Arrays might change size and overflow, etc)
+		public void setSectorTreeSeed( int n ) { sectorTreeSeed = n; }
 		public void setSectorLayoutSeed( int n ) { sectorLayoutSeed = n; }
 
 		/** Sets the fleet position, in pixels from far right of sector map. */
@@ -649,6 +653,7 @@ public class SavedGameParser extends DatParser {
 				result.append(playerShipState.toString().replaceAll("(^|\n)(.+)", "$1  $2"));
 
 			result.append("\nSector Data...\n");
+			result.append( String.format("Sector Tree Seed:   %5d\n", sectorTreeSeed) );
 			result.append( String.format("Sector Layout Seed: %5d\n", sectorLayoutSeed) );
 			result.append( String.format("Rebel Fleet Offset: %5d\n", rebelFleetOffset) );
 			result.append( String.format("Rebel Pursuit Mod:  %5d\n", rebelPursuitMod) );

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1171,6 +1171,9 @@ public class SavedGameParser extends DatParser {
 		public void addCrewMember( CrewState c ) {
 			crewList.add(c);
 		}
+		public CrewState getCrewMember( int n ) {
+			return crewList.get(n);
+		}
 
 		public ArrayList<CrewState> getCrewList() { return crewList; }
 
@@ -1180,11 +1183,17 @@ public class SavedGameParser extends DatParser {
 		public void addSystem( SystemState s ) {
 			systemMap.put( s.getName(), s );
 		}
+		public SystemState getSystem( String name ) {
+			return systemMap.get( name );
+		}
 
 		public LinkedHashMap<String, SystemState> getSystemMap() { return systemMap; }
 
 		public void addRoom( RoomState r ) {
 			roomList.add(r);
+		}
+		public RoomState getRoom( int roomId ) {
+			return roomList.get( roomId );
 		}
 
 		public ArrayList<RoomState> getRoomList() { return roomList; }
@@ -1213,6 +1222,10 @@ public class SavedGameParser extends DatParser {
 		public void setDoor( int wallX, int wallY, int vertical, DoorState d ) {
 			ShipLayout.DoorCoordinate doorCoord = new ShipLayout.DoorCoordinate( wallX, wallY, vertical );
 			doorMap.put(doorCoord, d);
+		}
+		public DoorState getDoor( int wallX, int wallY, int vertical ) {
+			ShipLayout.DoorCoordinate doorCoord = new ShipLayout.DoorCoordinate( wallX, wallY, vertical );
+			return doorMap.get(doorCoord);
 		}
 
 		public LinkedHashMap<ShipLayout.DoorCoordinate, DoorState> getDoorMap() { return doorMap; }
@@ -1583,6 +1596,9 @@ public class SavedGameParser extends DatParser {
 		 */
 		public void addSquare( int fireHealth, int ignitionProgress, int gamma ) {
 			squareList.add( new int[] {fireHealth, ignitionProgress, gamma} );
+		}
+		public int[] getSquare( int n ) {
+			return squareList.get(n);
 		}
 
 		public ArrayList<int[]> getSquareList() { return squareList; }

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -55,6 +55,7 @@ public class SavedGameParser extends DatParser {
 			int sectorNumber = readInt(in);
 			gameState.setSectorNumber( sectorNumber );
 
+			// Always 0?
 			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
 
 			int stateVarCount = readInt(in);
@@ -73,6 +74,9 @@ public class SavedGameParser extends DatParser {
 			
 			gameState.setRebelFleetOffset( readInt(in) );
 			
+			// Varies from sector to sector and among games,
+			// but consistent within a sector.
+			// Hex in wild: 68 78 92 94 B9 C8 C9 D9 F6 1A01 2301
 			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
 
 			gameState.setRebelPursuitMod( readInt(in) );
@@ -92,7 +96,7 @@ public class SavedGameParser extends DatParser {
 
 			int zeroBasedSectorNumber = readInt( in );  // Redundant.
 
-			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
+			gameState.setSectorIsHiddenCrystalWorlds( readBool(in) );
 			
 			int beaconCount = readInt(in);
 			for (int i=0; i < beaconCount; i++) {
@@ -463,6 +467,7 @@ public class SavedGameParser extends DatParser {
 		private int rebelFlagshipHop = 0;
 		private boolean rebelFlagshipApproaching = false;
 		private ArrayList<Boolean> sectorList = new ArrayList<Boolean>();
+		private boolean sectorIsHiddenCrystalWorlds = false;
 		private ArrayList<BeaconState> beaconList = new ArrayList<BeaconState>();
 		private LinkedHashMap<String, Integer> questEventMap = new LinkedHashMap<String, Integer>();
 		private ArrayList<String> distantQuestEventList = new ArrayList<String>();
@@ -550,6 +555,16 @@ public class SavedGameParser extends DatParser {
 		}
 
 		/**
+		 * Sets whether this sector is hidden.
+		 * The sector map will say "#? Hidden Crystal Worlds".
+		 *
+		 * When jumping from the exit beacon, you won't get to
+		 * choose which branch of the sector tree will be
+		 * next.
+		 */
+		public void setSectorIsHiddenCrystalWorlds( boolean b ) { sectorIsHiddenCrystalWorlds = b; }
+
+		/**
 		 * Adds a beacon to the sector map.
 		 * Beacons are indexed top-to-bottom for each column,
 		 * left-to-right. They're randomly offset a little
@@ -609,6 +624,7 @@ public class SavedGameParser extends DatParser {
 			result.append( String.format("Rebel Fleet Offset: %5d\n", rebelFleetOffset) );
 			result.append( String.format("Rebel Pursuit Mod:  %5d\n", rebelPursuitMod) );
 			result.append( String.format("Sector Hazards Map: %b\n", sectorHazardsVisible) );
+			result.append( String.format("In Hidden Sector:   %b\n", sectorIsHiddenCrystalWorlds) );
 			result.append( String.format("Rebel Flagship On:  %b\n", rebelFlagshipVisible) );
 			result.append( String.format("Flagship Nth Hop:   %5d\n", rebelFlagshipHop) );
 			result.append( String.format("Flagship Moving:    %b\n", rebelFlagshipApproaching) );
@@ -1227,7 +1243,7 @@ public class SavedGameParser extends DatParser {
 				result.append(String.format("Bkg Starscape:     %s\n", bgStarscapeImageInnerPath));
 				result.append(String.format("Bkg Sprite:        %s\n", bgSpriteImageInnerPath));
 				result.append(String.format("Bkg Sprite Coords: %3d,%3d\n", bgSpritePosX, bgSpritePosY));
-				result.append(String.format("Unknown:           %3d\n", unknownVisitedAlpha));
+				result.append(String.format("Unknown?:          %3d\n", unknownVisitedAlpha));
 			}
 			
 			result.append(String.format("Seen:              %b\n", seen));
@@ -1236,7 +1252,7 @@ public class SavedGameParser extends DatParser {
 			if ( enemyPresent ) {
 				result.append(String.format("  Ship Event ID:          %s\n", shipEventId));
 				result.append(String.format("  Ship Blueprint List ID: %s\n", shipBlueprintListId));
-				result.append(String.format("  Unknown:                %5d\n", unknownEnemyPresentAlpha));
+				result.append(String.format("  Unknown?:               %5d\n", unknownEnemyPresentAlpha));
 			}
 			
 			result.append(String.format("Fleets Present:    %s\n", fleetPresence));

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -446,7 +446,7 @@ public class SavedGameParser extends DatParser {
 		private String playerShipName = "";
 		private String playerShipBlueprintId = "";
 		private int sectorNumber = 1;
-		private HashMap<String, Integer> stateVars = new HashMap<String, Integer>();
+		private LinkedHashMap<String, Integer> stateVars = new LinkedHashMap<String, Integer>();
 		private ShipState playerShipState = null;
 		private ArrayList<String> cargoIdList = new ArrayList<String>();
 		private int sectorTreeSeed = 42;      // Arbitrary default.
@@ -476,6 +476,12 @@ public class SavedGameParser extends DatParser {
 		public void setTotalScrapCollected( int n ) { totalScrapCollected = n; }
 		public void setTotalCrewHired( int n ) { totalCrewHired = n; }
 
+		public boolean isDifficultyEasy() { return difficultyEasy; }
+		public int getTotalShipsDefeated() { return totalShipsDefeated; }
+		public int getTotalBeaconsExplored() { return totalBeaconsExplored; }
+		public int getTotalScrapCollected() { return totalScrapCollected; }
+		public int getTotalCrewHired() { return totalCrewHired; }
+
 		/**
 		 * Set redundant player ship info.
 		 */
@@ -483,10 +489,14 @@ public class SavedGameParser extends DatParser {
 			playerShipName = shipName;
 			playerShipBlueprintId = shipBlueprintId;
 		}
+		public String getShipName() { return playerShipName; }
+		public String getShipBlueprintId() { return playerShipBlueprintId; }
 
 		public void addCargoItemId( String cargoItemId ) {
 			cargoIdList.add( cargoItemId );
 		}
+
+		public ArrayList<String> getCargoIdList() { return cargoIdList; }
 
 		/**
 		 * Sets the current sector's number (0-based).
@@ -509,8 +519,10 @@ public class SavedGameParser extends DatParser {
 		 * but weird things might happen at or above #7.
 		 */
 		public void setSectorNumber( int n ) { sectorNumber = n; }
+		public int getSectorNumber() { return sectorNumber; }
 
 		public void setHeaderAlpha( int n ) { unknownHeaderAlpha = n; }
+		public int getHeaderAlpha() { return unknownHeaderAlpha; }
 
 		/**
 		 * Sets a state var.
@@ -538,14 +550,20 @@ public class SavedGameParser extends DatParser {
 			return result.intValue();
 		}
 
+		public LinkedHashMap<String, Integer> getStateVars() { return stateVars; }
+
 		public void setPlayerShipState( ShipState shipState ) {
 			this.playerShipState = shipState;
 		}
+		public ShipState getPlayerShipState() { return playerShipState; }
 
 		// TODO: See what havoc can occur when seeds change.
 		// (Arrays might change size and overflow, etc)
 		public void setSectorTreeSeed( int n ) { sectorTreeSeed = n; }
+		public int getSectorTreeSeed() { return sectorTreeSeed; }
+
 		public void setSectorLayoutSeed( int n ) { sectorLayoutSeed = n; }
+		public int getSectorLayoutSeed() { return sectorLayoutSeed; }
 
 		/**
 		 * Sets the fleet position on the map.
@@ -564,6 +582,7 @@ public class SavedGameParser extends DatParser {
 		 *          (see 'img/map/map_warningcircle_point.png', 650px wide)
 		 */
 		public void setRebelFleetOffset( int n ) { rebelFleetOffset = n; }
+		public int getRebelFleetOffset() { return rebelFleetOffset; }
 
 		/**
 		 * This is always a positive number around 100-300 that,
@@ -577,24 +596,30 @@ public class SavedGameParser extends DatParser {
 		 * both edges of the map).
 		 */
 		public void setRebelFleetFudge( int n ) { rebelFleetFudge = n; }
+		public int getRebelFleetFudge() { return rebelFleetFudge; }
 
 		/**
 		 * Delays/alerts the rebel fleet (-/+).
 		 * Example: Hiring a merc ship to distract sets -2.
 		 */
 		public void setRebelPursuitMod( int n ) { rebelPursuitMod = n; }
+		public int getRebelPursuitMod() { return rebelPursuitMod; }
 
 		/** Toggles visibility of beacon hazards for this sector. */
 		public void setSectorHazardsVisible( boolean b ) { sectorHazardsVisible = b; }
+		public boolean areSectorHazardsVisible() { return sectorHazardsVisible; }
 
 		/** Toggles the flagship. Instant lose if not in sector 8. */
 		public void setRebelFlagshipVisible( boolean b ) { rebelFlagshipVisible = b; }
+		public boolean isRebelFlagshipVisible() { return rebelFlagshipVisible; }
 
 		/** Set's the flagship's next/current beacon, as an index of a fixed list? */
 		public void setRebelFlagshipHop( int n ) { rebelFlagshipHop = n; }
+		public int getRebelFlagshipHop() { return rebelFlagshipHop; }
 
 		/** Sets whether the flagship's approaching or circling its hop beacon. */
 		public void setRebelFlagshipApproaching( boolean b ) { rebelFlagshipApproaching = b; }
+		public boolean isRebelFlagshipApproaching() { return rebelFlagshipApproaching; }
 
 		/**
 		 * Adds a dot of the sector tree.
@@ -608,6 +633,8 @@ public class SavedGameParser extends DatParser {
 			sectorList.set( sector, new Boolean(visited) );
 		}
 
+		public ArrayList<Boolean> getSectorList() { return sectorList; }
+
 		/**
 		 * Sets whether this sector is hidden.
 		 * The sector map will say "#? Hidden Crystal Worlds".
@@ -617,6 +644,7 @@ public class SavedGameParser extends DatParser {
 		 * next.
 		 */
 		public void setSectorIsHiddenCrystalWorlds( boolean b ) { sectorIsHiddenCrystalWorlds = b; }
+		public boolean isSectorHiddenCrystalWorlds() { return sectorIsHiddenCrystalWorlds; }
 
 		/**
 		 * Adds a beacon to the sector map.
@@ -628,28 +656,45 @@ public class SavedGameParser extends DatParser {
 			beaconList.add( beacon );
 		}
 
+		public ArrayList<BeaconState> getBeaconList() { return beaconList; }
+
 		public void addQuestEvent( String questEventId, int questBeaconId ) {
 			questEventMap.put( questEventId, new Integer(questBeaconId) );
+		}
+
+		public LinkedHashMap<String, Integer> getQuestEventMap() {
+			return questEventMap;
 		}
 
 		public void addDistantQuestEvent( String questEventId ) {
 			distantQuestEventList.add( questEventId );
 		}
 
+		public ArrayList<String> getDistantQuestEventList() {
+			return distantQuestEventList;
+		}
+
 		/** Sets where the player is. */
 		public void setCurrentBeaconId( int n ) { currentBeaconId = n; }
+		public int getCurrentBeaconId() { return currentBeaconId; }
 
 		public void setNearbyShipState( ShipState shipState ) {
 			this.nearbyShipState = shipState;
 		}
+		public ShipState getNearbyShipState() { return nearbyShipState; }
 
 		public void setRebelFlagshipState( RebelFlagshipState flagshipState ) {
 			this.rebelFlagshipState = flagshipState;
+		}
+		public RebelFlagshipState getRebelFlagshipState() {
+			return rebelFlagshipState;
 		}
 
 		public void addMysteryBytes( MysteryBytes m ) {
 			mysteryList.add(m);
 		}
+
+		public ArrayList<MysteryBytes> getMysteryList() { return mysteryList; }
 
 		@Override
 		public String toString() {
@@ -769,6 +814,11 @@ public class SavedGameParser extends DatParser {
 			this.auto = auto;
 		}
 
+		public String getShipName() { return shipName; }
+		public String getShipBlueprintId() { return shipBlueprintId; }
+		public String getShipLayoutId() { return shipLayoutId; }
+		public boolean isAuto() { return auto; }
+
 		/**
 		 * Sets the basename to use when loading ship images.
 		 * See 'img/ship/basename_*.png'.
@@ -782,9 +832,14 @@ public class SavedGameParser extends DatParser {
 		public void setShipGraphicsBaseName( String shipGfxBaseName ) {
 			this.shipGfxBaseName = shipGfxBaseName;
 		}
+		public String getShipGraphicsBaseName() { return shipGfxBaseName; }
 
 		public void addStartingCrewMember( StartingCrewState sc ) {
 			startingCrewList.add(sc);
+		}
+
+		public ArrayList<StartingCrewState> getStartingCrewList() {
+			return startingCrewList;
 		}
 
 		public void setHullAmt( int n ) { hullAmt = n; }
@@ -793,21 +848,32 @@ public class SavedGameParser extends DatParser {
 		public void setMissilesAmt( int n ) { missilesAmt = n; }
 		public void setScrapAmt( int n ) { scrapAmt = n; }
 
+		public int getHullAmt() { return hullAmt; }
+		public int getFuelAmt() { return fuelAmt; }
+		public int getDronePartsAmt() { return dronePartsAmt; }
+		public int getMissilesAmt() { return missilesAmt; }
+		public int getScrapAmt() { return scrapAmt; }
+
 		public void addCrewMember( CrewState c ) {
 			crewList.add(c);
 		}
 
-		public void setReservePowerCapacity( int n ) {
-			reservePowerCapacity = n;
-		}
+		public ArrayList<CrewState> getCrewList() { return crewList; }
+
+		public void setReservePowerCapacity( int n ) { reservePowerCapacity = n; }
+		public int getReservePowerCapacity() { return reservePowerCapacity; }
 
 		public void addSystem( SystemState s ) {
 			systemList.add(s);
 		}
 
+		public ArrayList<SystemState> getSystemList() { return systemList; }
+
 		public void addRoom( RoomState r ) {
 			roomList.add(r);
 		}
+
+		public ArrayList<RoomState> getRoomList() { return roomList; }
 
 		/**
 		 * Adds a hull breach.
@@ -819,6 +885,8 @@ public class SavedGameParser extends DatParser {
 		public void setBreach( int x, int y, int breachHealth ) {
 			breachMap.put( new Point(x, y), new Integer(breachHealth) );
 		}
+
+		public LinkedHashMap<Point, Integer> getBreachMap() { return breachMap; }
 
 		/**
 		 * Adds a door.
@@ -833,17 +901,25 @@ public class SavedGameParser extends DatParser {
 			doorMap.put(doorCoord, d);
 		}
 
+		public LinkedHashMap<int[], DoorState> getDoorMap() { return doorMap; }
+
 		public void addWeapon( WeaponState w ) {
 			weaponList.add(w);
 		}
+
+		public ArrayList<WeaponState> getWeaponList() { return weaponList; }
 
 		public void addDrone( DroneState d ) {
 			droneList.add(d);
 		}
 
+		public ArrayList<DroneState> getDroneList() { return droneList; }
+
 		public void addAugmentId( String augmentId ) {
 			augmentIdList.add(augmentId);
 		}
+
+		public ArrayList<String> getAugmentIdList() { return augmentIdList; }
 		
 		@Override
 		public String toString() {
@@ -1016,8 +1092,6 @@ public class SavedGameParser extends DatParser {
 		private int x, y;
 		private int gender;  // 1=Male, 0=Female.
 
-		private int unknownAlpha;
-
 		public CrewState() {
 		}
 
@@ -1042,6 +1116,27 @@ public class SavedGameParser extends DatParser {
 		public void setJumpsSurvived( int n ) { jumpsSurvived = n; }
 		public void setSkillMasteries( int n ) { skillMasteries = n; }
 
+		public String getName() { return name; }
+		public String getRace() { return race; }
+		public int getHealth() { return health; }
+		public int getX() { return x; }
+		public int getY() { return y; }
+		public int getRoomId() { return blueprintRoomId; }
+		public int getRoomSquare() { return roomSquare; }
+		public boolean isPlayerControlled() { return playerControlled; }
+		public int getPilotSkill() { return pilotSkill; }
+		public int getEngineSkill() { return engineSkill; }
+		public int getShieldSkill() { return shieldSkill; }
+		public int getWeaponSkill() { return weaponSkill; }
+		public int getRepairSkill() { return repairSkill; }
+		public int getCombatSkill() { return combatSkill; }
+		public int getGender() { return gender; }
+		public int getRepairs() { return repairs; }
+		public int getCombatKills() { return combatKills; }
+		public int getPilotedEvasions() { return pilotedEvasions; }
+		public int getJumpsSurvived() { return jumpsSurvived; }
+		public int getSkillMasteries() { return skillMasteries; }
+
 		/**
 		 * Sets whether this crew member is a hostile drone.
 		 * Bizarrely, this trumps race and playerControlled.
@@ -1053,6 +1148,7 @@ public class SavedGameParser extends DatParser {
 		public void setEnemyBoardingDrone( boolean b ) {
 			enemyBoardingDrone = b;
 		}
+		public boolean isEnemyBoardingDrone() { return enemyBoardingDrone; }
 
 		@Override
 		public String toString() {
@@ -1115,6 +1211,8 @@ public class SavedGameParser extends DatParser {
 			this.name = name;
 		}
 
+		public String getName() { return name; }
+
 		public void setCapacity( int n ) { capacity = n; }
 		public void setPower( int n ) { power = n; }
 		public void setDamagedBars( int n ) { damagedBars = n; }
@@ -1122,6 +1220,14 @@ public class SavedGameParser extends DatParser {
 		public void setRepairProgress( int n ) { repairProgress = n; }
 		public void setBurnProgress( int n ) { burnProgress = n; }
 		public void setMiscTicks( int n ) { miscTicks = n; }
+
+		public int getCapacity() { return capacity; }
+		public int getPower() { return power; }
+		public int getDamagedBars() { return damagedBars; }
+		public int getIonizedBars() { return ionizedBars; }
+		public int getRepairProgress() { return repairProgress; }
+		public int getBurnProgress() { return burnProgress; }
+		public int getMiscTicks() { return miscTicks; }
 
 		@Override
 		public String toString() {
@@ -1147,6 +1253,7 @@ public class SavedGameParser extends DatParser {
 		private ArrayList<int[]> squareList = new ArrayList<int[]>();
 
 		public void setOxygen( int n ) { oxygen = n; }
+		public int getOxygen() { return oxygen; }
 
 		/**
 		 * Adds a floor square to the room.
@@ -1163,6 +1270,8 @@ public class SavedGameParser extends DatParser {
 		public void addSquare( int fireHealth, int ignitionProgress, int gamma ) {
 			squareList.add( new int[] {fireHealth, ignitionProgress, gamma} );
 		}
+
+		public ArrayList<int[]> getSquareList() { return squareList; }
 
 		@Override
 		public String toString() {
@@ -1187,6 +1296,12 @@ public class SavedGameParser extends DatParser {
 			this.unknownAlpha = alpha;
 		}
 
+		public void setOpen( boolean b ) { open = b; }
+		public void setAlpha( int n ) { unknownAlpha = n; }
+
+		public boolean isOpen() { return open; }
+		public int getAlpha() { return unknownAlpha; }
+
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
@@ -1207,6 +1322,17 @@ public class SavedGameParser extends DatParser {
 			this.armed = armed;
 			this.cooldownTicks = cooldownTicks;
 		}
+
+		public String getWeaponId() { return weaponId; }
+
+		public void setArmed( boolean b ) {
+			armed = b;
+			if ( b == false ) cooldownTicks = 0;
+		}
+		public boolean isArmed() { return armed; }
+
+		public void setCooldownTicks( int n ) { cooldownTicks = n; }
+		public int getCooldownTicks() { return cooldownTicks; }
 
 		@Override
 		public String toString() {
@@ -1238,6 +1364,8 @@ public class SavedGameParser extends DatParser {
 			this.droneId = droneId;
 		}
 
+		public String getDroneId() { return droneId; }
+
 		public void setArmed( boolean b ) { armed = b; }
 		public void setPlayerControlled( boolean b ) { playerControlled = b; }
 		public void setX( int n ) { x = n; }
@@ -1245,6 +1373,14 @@ public class SavedGameParser extends DatParser {
 		public void setRoomId( int n ) { blueprintRoomId = n; }
 		public void setRoomSquare( int n ) { roomSquare = n; }
 		public void setHealth( int n ) { health = n; }
+
+		public boolean isArmed() { return armed; }
+		public boolean isPlayerControlled() { return playerControlled; }
+		public int getX() { return x; }
+		public int getY() { return y; }
+		public int getRoomId() { return blueprintRoomId; }
+		public int getRoomSquare() { return roomSquare; }
+		public int getHealth() { return health; }
 
 		@Override
 		public String toString() {
@@ -1495,6 +1631,9 @@ public class SavedGameParser extends DatParser {
 			return result.toString();
 		}
 
+		public List<StoreItem> getItems() {
+			return items;
+		}
 		public StoreItemType getItemType() {
 			return itemType;
 		}
@@ -1514,6 +1653,14 @@ public class SavedGameParser extends DatParser {
 		public StoreItem(boolean available, String itemId) {
 			this.available = available;
 			this.itemId = itemId;
+		}
+
+		public boolean isAvailable() {
+			return available;
+		}
+
+		public String getItemId() {
+			return itemId;
 		}
 
 		@Override
@@ -1541,6 +1688,10 @@ public class SavedGameParser extends DatParser {
 			this.shipBlueprintIds = shipBlueprintIds;
 		}
 
+		public String[] getShipBlueprintIds() {
+			return shipBlueprintIds;
+		}
+
 		/**
 		 * Sets the next version of the flagship that will be encountered (1-based).
 		 */
@@ -1548,6 +1699,9 @@ public class SavedGameParser extends DatParser {
 			if ( pendingStage <= 0 || pendingStage > shipBlueprintIds.length )
 				throw new IndexOutOfBoundsException( "Attempted to set 1-based flagship stage "+ pendingStage +" of "+ shipBlueprintIds.length +" total" );
 			this.pendingStage = pendingStage;
+		}
+		public int getPendingStage() {
+			return pendingStage;
 		}
 
 		/**
@@ -1575,6 +1729,10 @@ public class SavedGameParser extends DatParser {
 		 */
 		public void setPreviousOccupancy( int roomId, int n ) {
 			occupancyMap.put( new Integer(roomId), new Integer(n) );
+		}
+
+		public LinkedHashMap<Integer, Integer> getOccupancyMap() {
+			return occupancyMap;
 		}
 
 		@Override

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -67,6 +67,12 @@ public class SavedGameParser extends DatParser {
 			ShipState playerShipState = readShip( in, true );
 			gameState.setPlayerShipState( playerShipState );
 
+			// Nearby ships have no cargo, so this isn't in readShip().
+			int cargoCount = readInt(in);
+			for (int i=0; i < cargoCount; i++) {
+				gameState.addCargoItemId( readString(in) );
+			}
+
 			gameState.setSectorTreeSeed( readInt(in) );
 			
 			gameState.setSectorLayoutSeed( readInt(in) );
@@ -254,11 +260,6 @@ public class SavedGameParser extends DatParser {
 		int augmentCount = readInt(in);
 		for (int i=0; i < augmentCount; i++) {
 			shipState.addAugmentId( readString(in) );
-		}
-
-		int cargoCount = readInt(in);  // TODO: Nearby ships say 1, but have none?
-		for (int i=0; i < cargoCount; i++) {
-			shipState.addCargoItemId( readString(in) );
 		}
 
 		return shipState;
@@ -500,6 +501,10 @@ public class SavedGameParser extends DatParser {
 			playerShipBlueprintId = shipBlueprintId;
 		}
 
+		public void addCargoItemId( String cargoItemId ) {
+			cargoIdList.add( cargoItemId );
+		}
+
 		/**
 		 * Sets the current sector's number (0-based).
 		 *
@@ -652,6 +657,11 @@ public class SavedGameParser extends DatParser {
 			if ( playerShipState != null )
 				result.append(playerShipState.toString().replaceAll("(^|\n)(.+)", "$1  $2"));
 
+			result.append("\nCargo...\n");
+			for (String cargoItemId : cargoIdList) {
+				result.append(String.format("CargoItemId: %s\n", cargoItemId));
+			}
+
 			result.append("\nSector Data...\n");
 			result.append( String.format("Sector Tree Seed:   %5d\n", sectorTreeSeed) );
 			result.append( String.format("Sector Layout Seed: %5d\n", sectorLayoutSeed) );
@@ -733,7 +743,6 @@ public class SavedGameParser extends DatParser {
 		private ArrayList<WeaponState> weaponList = new ArrayList<WeaponState>();
 		private ArrayList<DroneState> droneList = new ArrayList<DroneState>();
 		private ArrayList<String> augmentIdList = new ArrayList<String>();
-		private ArrayList<String> cargoIdList = new ArrayList<String>();
 
 		public ShipState(String shipName, String shipBlueprintId, String shipLayoutId, boolean auto) {
 			this.shipName = shipName;
@@ -818,10 +827,6 @@ public class SavedGameParser extends DatParser {
 			augmentIdList.add(augmentId);
 		}
 		
-		public void addCargoItemId( String cargoItemId ) {
-			cargoIdList.add( cargoItemId );
-		}
-
 		@Override
 		public String toString() {
 			// The blueprint fetching might vary if auto == true.
@@ -934,11 +939,6 @@ public class SavedGameParser extends DatParser {
 				result.append(String.format("AugmentId: %s\n", augmentId));
 			}
 			
-			result.append("\nCargo...\n");
-			for (String cargoItemId : cargoIdList) {
-				result.append(String.format("CargoItemId: %s\n", cargoItemId));
-			}
-
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -55,7 +55,7 @@ public class SavedGameParser extends DatParser {
 			int oneBasedSectorNumber = readInt(in);  // Redundant.
 
 			// Always 0?
-			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
+			gameState.setHeaderAlpha( readInt(in) );
 
 			int stateVarCount = readInt(in);
 			for (int i=0; i < stateVarCount; i++) {
@@ -470,6 +470,8 @@ public class SavedGameParser extends DatParser {
 		private RebelFlagshipState rebelFlagshipState = null;
 		private ArrayList<MysteryBytes> mysteryList = new ArrayList<MysteryBytes>();
 
+		private int unknownHeaderAlpha = 0;
+
 		public void setDifficultyEasy( boolean b ) { difficultyEasy = b; }
 		public void setTotalShipsDefeated( int n ) { totalShipsDefeated = n; }
 		public void setTotalBeaconsExplored( int n ) { totalBeaconsExplored = n; }
@@ -509,6 +511,8 @@ public class SavedGameParser extends DatParser {
 		 * but weird things might happen at or above #7.
 		 */
 		public void setSectorNumber( int n ) { sectorNumber = n; }
+
+		public void setHeaderAlpha( int n ) { unknownHeaderAlpha = n; }
 
 		/**
 		 * Sets a state var.
@@ -624,8 +628,9 @@ public class SavedGameParser extends DatParser {
 			boolean first = true;
 			result.append(String.format("Ship Name: %s\n", playerShipName));
 			result.append(String.format("Ship Type: %s\n", playerShipBlueprintId));
-			result.append(String.format("Sector:                 %4d (%d)\n", sectorNumber, sectorNumber+1));
 			result.append(String.format("Difficulty:             %s\n", (difficultyEasy ? "Easy" : "Normal") ));
+			result.append(String.format("Sector:                 %4d (%d)\n", sectorNumber, sectorNumber+1));
+			result.append(String.format("Unknown?:               %4d\n", unknownHeaderAlpha));
 			result.append(String.format("Total Ships Defeated:   %4d\n", totalShipsDefeated));
 			result.append(String.format("Total Beacons Explored: %4d\n", totalBeaconsExplored));
 			result.append(String.format("Total Scrap Collected:  %4d\n", totalScrapCollected));

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -581,14 +581,14 @@ public class SavedGameParser extends DatParser {
 
 	private DoorState readDoor( InputStream in ) throws IOException {
 		boolean open = readBool(in);
-		int alpha = readInt(in);  // 0. What else would a door have; damage?
-		DoorState door = new DoorState( open, alpha );
+		boolean walkingThrough = readBool(in);
+		DoorState door = new DoorState( open, walkingThrough );
 		return door;
 	}
 
 	public void writeDoor( OutputStream out, DoorState door ) throws IOException {
 		writeBool( out, door.isOpen() );
-		writeInt( out, door.getAlpha() );
+		writeBool( out, door.isWalkingThrough() );
 	}
 
 	private DroneState readDrone( InputStream in ) throws IOException {
@@ -1512,11 +1512,17 @@ public class SavedGameParser extends DatParser {
 
 		/**
 		 * Sets whether this crew member is a hostile drone.
-		 * Bizarrely, this trumps race and playerControlled.
+		 * Upon loading after setting this on your crew,
+		 * name will change to "Anti-Personnel Drone", race
+		 * will be "battle", and playerControlled will be
+		 * false.
 		 *
 		 * Presumably this is so intruders can persist without
 		 * a ship, which would normally have a drones section
 		 * to contain them.
+		 *
+		 * TODO: Jump away from Boss #2 to see what its
+		 * drone is (blueprints.xml mentions BOARDER_BOSS).
 		 */
 		public void setEnemyBoardingDrone( boolean b ) {
 			enemyBoardingDrone = b;
@@ -1664,24 +1670,23 @@ public class SavedGameParser extends DatParser {
 
 	public class DoorState {
 		private boolean open;
+		private boolean walkingThrough;
 
-		private int unknownAlpha;
-
-		public DoorState( boolean open, int alpha ) {
+		public DoorState( boolean open, boolean walkingThrough ) {
 			this.open = open;
-			this.unknownAlpha = alpha;
+			this.walkingThrough = walkingThrough;
 		}
 
 		public void setOpen( boolean b ) { open = b; }
-		public void setAlpha( int n ) { unknownAlpha = n; }
+		public void setWalkingThrough( boolean b ) { walkingThrough = b; }
 
 		public boolean isOpen() { return open; }
-		public int getAlpha() { return unknownAlpha; }
+		public boolean isWalkingThrough() { return walkingThrough; }
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
-			result.append(String.format("Open: %b, Alpha?: %d\n", open, unknownAlpha));
+			result.append(String.format("Open: %b, Walking Through: %b\n", open, walkingThrough));
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -139,30 +139,12 @@ public class SavedGameParser extends DatParser {
 				gameState.setNearbyShipState(nearbyShipState);
 			}
 
-			// Here, the stream might end.
+			RebelFlagshipState flagshipState = readRebelFlagship(in);
+			gameState.setRebelFlagshipState( flagshipState );
+
+			// The stream should end here.
 
 			int bytesRemaining = (int)(in.getChannel().size() - in.getChannel().position());
-
-			// Or, if this is sector 8 and the boss has been engaged at
-			// least once, this will definitely be present.
-			if ( sectorNumber == 7 && bytesRemaining > 2*4 ) {
-				RebelFlagshipState flagshipState = readRebelFlagship(in);
-				gameState.setRebelFlagshipState( flagshipState );
-			}
-
-			// Otherwise this is sometimes present...
-			// This hasn't been observed to coincide with the above, but
-			// this is intermittent in all sectors, which would be
-			// odd if it were boss related.
-			//
-			//   0x0100_0000 0x0000_0000 == 1 0 as ints. No idea what for.
-			//
-			// Making this 2 0 before engaging the boss for the first time
-			// will result in skipping to stage 2 with 0 crew. So the
-			// parser COULD treat it as boss info if it's never shown to
-			// be otherwise important.
-
-			bytesRemaining = (int)(in.getChannel().size() - in.getChannel().position());
 			if ( bytesRemaining > 0 ) {
 				gameState.addMysteryBytes( new MysteryBytes(in, bytesRemaining) );
 			}
@@ -469,6 +451,7 @@ public class SavedGameParser extends DatParser {
 		private int sectorNumber = 1;
 		private HashMap<String, Integer> stateVars = new HashMap<String, Integer>();
 		private ShipState playerShipState = null;
+		private ArrayList<String> cargoIdList = new ArrayList<String>();
 		private int sectorTreeSeed;
 		private int sectorLayoutSeed;
 		private int rebelFleetOffset;

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1238,8 +1238,8 @@ public class SavedGameParser extends DatParser {
 		/**
 		 * Adds a hull breach.
 		 *
-		 * @param x the 0-based Nth floor-square from the left (minus ShipLayout X_OFFSET)
-		 * @param y the 0-based Nth floor-square from the top (minus ShipLayout Y_OFFSET)
+		 * @param x the 0-based Nth floor-square from the left (plus ShipLayout X_OFFSET)
+		 * @param y the 0-based Nth floor-square from the top (plus ShipLayout Y_OFFSET)
 		 * @param breachHealth 0 to 100.
 		 */
 		public void setBreach( int x, int y, int breachHealth ) {

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -79,10 +79,7 @@ public class SavedGameParser extends DatParser {
 			
 			gameState.setRebelFleetOffset( readInt(in) );
 			
-			// Varies from sector to sector and among games,
-			// but consistent within a sector.
-			// Hex in wild: 68 78 92 94 B9 C8 C9 D9 F6 1A01 2301
-			gameState.addMysteryBytes( new MysteryBytes(in, 4) );
+			gameState.setRebelFleetFudge( readInt(in) );
 
 			gameState.setRebelPursuitMod( readInt(in) );
 
@@ -452,9 +449,10 @@ public class SavedGameParser extends DatParser {
 		private HashMap<String, Integer> stateVars = new HashMap<String, Integer>();
 		private ShipState playerShipState = null;
 		private ArrayList<String> cargoIdList = new ArrayList<String>();
-		private int sectorTreeSeed;
-		private int sectorLayoutSeed;
-		private int rebelFleetOffset;
+		private int sectorTreeSeed = 42;      // Arbitrary default.
+		private int sectorLayoutSeed = 42;    // Arbitrary default.
+		private int rebelFleetOffset = -750;  // Arbitrary default.
+		private int rebelFleetFudge = 100;    // Arbitrary default.
 		private int rebelPursuitMod = 0;
 		private boolean sectorHazardsVisible = false;
 		private boolean rebelFlagshipVisible = false;
@@ -549,10 +547,41 @@ public class SavedGameParser extends DatParser {
 		public void setSectorTreeSeed( int n ) { sectorTreeSeed = n; }
 		public void setSectorLayoutSeed( int n ) { sectorLayoutSeed = n; }
 
-		/** Sets the fleet position, in pixels from far right of sector map. */
+		/**
+		 * Sets the fleet position on the map.
+		 * This is always a negative value that, when added to
+		 * rebelFleetFudge, equals how far in from the left the
+		 * warning circle has encroached (image has ~50px margin).
+		 *
+		 * Most sectors start with large negative value to keep
+		 * this off-screen and increment toward 0 from there.
+		 * The Last Stand sector uses a constant -25 and moderate
+		 * rebelFleetFudge value to cover the map.
+		 *
+		 * This has always been observed in multiples of 25.
+		 *
+		 * @param n pixels from the map's right edge
+		 *          (see 'img/map/map_warningcircle_point.png', 650px wide)
+		 */
 		public void setRebelFleetOffset( int n ) { rebelFleetOffset = n; }
 
-		/** Delays/alerts the rebel fleet (-/+). */
+		/**
+		 * This is always a positive number around 100-300 that,
+		 * when added to rebelFleetOffset, equals how far in
+		 * from the left the warning circle has encroached.
+		 *
+		 * This varies seemingly randomly from game to game and
+		 * sector to sector, but it's consistent while within
+		 * each sector. Except in The Last Stand, in which it is
+		 * always 200 (the warning circle will extend beyond
+		 * both edges of the map).
+		 */
+		public void setRebelFleetFudge( int n ) { rebelFleetFudge = n; }
+
+		/**
+		 * Delays/alerts the rebel fleet (-/+).
+		 * Example: Hiring a merc ship to distract sets -2.
+		 */
 		public void setRebelPursuitMod( int n ) { rebelPursuitMod = n; }
 
 		/** Toggles visibility of beacon hazards for this sector. */
@@ -654,6 +683,7 @@ public class SavedGameParser extends DatParser {
 			result.append( String.format("Sector Tree Seed:   %5d\n", sectorTreeSeed) );
 			result.append( String.format("Sector Layout Seed: %5d\n", sectorLayoutSeed) );
 			result.append( String.format("Rebel Fleet Offset: %5d\n", rebelFleetOffset) );
+			result.append( String.format("Rebel Fleet Fudge:  %5d\n", rebelFleetFudge) );
 			result.append( String.format("Rebel Pursuit Mod:  %5d\n", rebelPursuitMod) );
 			result.append( String.format("Sector Hazards Map: %b\n", sectorHazardsVisible) );
 			result.append( String.format("In Hidden Sector:   %b\n", sectorIsHiddenCrystalWorlds) );

--- a/src/main/java/net/blerf/ftl/ui/FTLFrame.java
+++ b/src/main/java/net/blerf/ftl/ui/FTLFrame.java
@@ -11,6 +11,7 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
+import java.awt.image.RasterFormatException;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -271,34 +272,27 @@ public class FTLFrame extends JFrame {
 		if (race == null || race.length() == 0) return null;
 
 		ImageIcon result = null;
-		int offsetX = 0, offsetY = 0, w = 36, h = 36;
+		int offsetX = 0, offsetY = 0, w = 35, h = 35;
 		InputStream in = null;
 		try {
 			in = DataManager.get().getResourceInputStream("img/people/"+ race +"_player_yellow.png");
-			BufferedImage big = ImageIO.read( in );
-			if (offsetX+w <= big.getWidth() || offsetY+h <= big.getHeight()) {
-				BufferedImage cropped = big.getSubimage(offsetX, offsetY, w, h);
+			BufferedImage bigImage = ImageIO.read( in );
+			BufferedImage croppedImage = bigImage.getSubimage(offsetX, offsetY, w, h);
 
-				// Shrink the crop area until non-transparent pixels are hit.
-				int lowX = Integer.MAX_VALUE, lowY = Integer.MAX_VALUE;
-				int highX = -1, highY = -1;
-				for (int testY=0; testY < h; testY++) {
-					for (int testX=0; testX < w; testX++) {
-						int pixel = cropped.getRGB(testX, testY);
-						int alpha = (pixel >> 24) & 0xFF;  // 24:A, 16:R, 8:G, 0:B.
-						if (alpha != 0) {
-							if (testX > highX) highX = testX;
-							if (testY > highY) highY = testY;
-							if (testX < lowX) lowX = testX;
-							if (testY < lowY) lowY = testY;
-						}
+			// Shrink the crop area until non-transparent pixels are hit.
+			int lowX = Integer.MAX_VALUE, lowY = Integer.MAX_VALUE;
+			int highX = -1, highY = -1;
+			for (int testY=0; testY < h; testY++) {
+				for (int testX=0; testX < w; testX++) {
+					int pixel = croppedImage.getRGB(testX, testY);
+					int alpha = (pixel >> 24) & 0xFF;  // 24:A, 16:R, 8:G, 0:B.
+					if (alpha != 0) {
+						if (testX > highX) highX = testX;
+						if (testY > highY) highY = testY;
+						if (testX < lowX) lowX = testX;
+						if (testY < lowY) lowY = testY;
 					}
 				}
-				log.trace("Crew Icon Trim Bounds: "+ lowX +","+ lowY +" "+ highX +"x"+ highY +" "+ race);
-				if (lowX >= 0 && lowY >= 0 && highX < w && highY < h && lowX < highX && lowY < highY) {
-					cropped = cropped.getSubimage(lowX, lowY, highX-lowX+1, highY-lowY+1);
-				}
-				result = new ImageIcon(cropped);
 			}
 
 		} catch (IOException e) {

--- a/src/main/java/net/blerf/ftl/ui/FTLFrame.java
+++ b/src/main/java/net/blerf/ftl/ui/FTLFrame.java
@@ -74,6 +74,7 @@ import net.blerf.ftl.ui.GeneralAchievementsPanel;
 import net.blerf.ftl.ui.ProfileStatsPanel;
 import net.blerf.ftl.ui.SavedGameDumpPanel;
 import net.blerf.ftl.ui.SavedGameGeneralPanel;
+import net.blerf.ftl.ui.SavedGameFloorplanPanel;
 import net.blerf.ftl.ui.ShipUnlockPanel;
 import net.blerf.ftl.ui.StatusbarMouseListener;
 import net.blerf.ftl.xml.Achievement;
@@ -118,6 +119,7 @@ public class FTLFrame extends JFrame {
 	private ProfileStatsPanel statsPanel;
 	private SavedGameDumpPanel savedGameDumpPanel;
 	private SavedGameGeneralPanel savedGameGeneralPanel;
+	private SavedGameFloorplanPanel savedGameFloorplanPanel;
 	private JLabel statusLbl;
 	private final HyperlinkListener linkListener;
 	
@@ -193,9 +195,11 @@ public class FTLFrame extends JFrame {
 
 		savedGameDumpPanel = new SavedGameDumpPanel(this);
 		savedGameGeneralPanel = new SavedGameGeneralPanel(this);
+		savedGameFloorplanPanel = new SavedGameFloorplanPanel(this);
 
 		savedGameTabsPane.add( "Dump", savedGameDumpPanel);
-		savedGameTabsPane.add( "Edit", new JScrollPane( savedGameGeneralPanel ) );
+		savedGameTabsPane.add( "General Editing", new JScrollPane( savedGameGeneralPanel ) );
+		savedGameTabsPane.add( "Ship Thumbnail", new JScrollPane( savedGameFloorplanPanel ) );
 
 
 		JPanel statusPanel = new JPanel();
@@ -294,6 +298,14 @@ public class FTLFrame extends JFrame {
 					}
 				}
 			}
+			log.trace("Crew Icon Trim Bounds: "+ lowX +","+ lowY +" "+ highX +"x"+ highY +" "+ race);
+			if (lowX >= 0 && lowY >= 0 && highX < w && highY < h && lowX < highX && lowY < highY) {
+				croppedImage = croppedImage.getSubimage(lowX, lowY, highX-lowX+1, highY-lowY+1);
+			}
+			result = new ImageIcon(croppedImage);
+
+		} catch (RasterFormatException e) {
+			log.error( "Failed to load and crop race ("+ race +")", e );
 
 		} catch (IOException e) {
 			log.error( "Failed to load and crop race ("+ race +")", e );
@@ -937,6 +949,7 @@ public class FTLFrame extends JFrame {
 	public void loadGameState( SavedGameParser.SavedGameState gs ) {
 
 		savedGameDumpPanel.setGameState( gs );
+		savedGameFloorplanPanel.setGameState( gs );
 		savedGameGeneralPanel.setGameState( gs );
 
 		gameState = gs;

--- a/src/main/java/net/blerf/ftl/ui/FTLFrame.java
+++ b/src/main/java/net/blerf/ftl/ui/FTLFrame.java
@@ -65,6 +65,7 @@ import net.blerf.ftl.model.Score;
 import net.blerf.ftl.model.Score.Difficulty;
 import net.blerf.ftl.model.Stats;
 import net.blerf.ftl.parser.DataManager;
+import net.blerf.ftl.parser.MysteryBytes;
 import net.blerf.ftl.parser.ProfileParser;
 import net.blerf.ftl.parser.SavedGameParser;
 import net.blerf.ftl.ui.ExtensionFileFilter;
@@ -590,6 +591,18 @@ public class FTLFrame extends JFrame {
 						loadGameState( gs );
 
 						log.trace( "Read completed successfully" );
+
+						if ( gameState.getMysteryList().size() > 0 ) {
+							StringBuilder musteryBuf = new StringBuilder();
+							musteryBuf.append("This saved game file contains mystery bytes the developers hadn't anticipated!\n");
+							boolean first = true;
+							for (MysteryBytes m : gameState.getMysteryList()) {
+								if (first) { first = false; }
+								else { musteryBuf.append(",\n"); }
+								musteryBuf.append(m.toString().replaceAll("(^|\n)(.+)", "$1  $2"));
+							}
+							log.warn( musteryBuf.toString() );
+						}
 						
 					} catch( Exception f ) {
 						log.error( "Error reading saved game", f );

--- a/src/main/java/net/blerf/ftl/ui/FTLFrame.java
+++ b/src/main/java/net/blerf/ftl/ui/FTLFrame.java
@@ -198,8 +198,8 @@ public class FTLFrame extends JFrame {
 		savedGameFloorplanPanel = new SavedGameFloorplanPanel(this);
 
 		savedGameTabsPane.add( "Dump", savedGameDumpPanel);
-		savedGameTabsPane.add( "General Editing", new JScrollPane( savedGameGeneralPanel ) );
-		savedGameTabsPane.add( "Ship Thumbnail", new JScrollPane( savedGameFloorplanPanel ) );
+		savedGameTabsPane.add( "General", new JScrollPane( savedGameGeneralPanel ) );
+		savedGameTabsPane.add( "Ship", savedGameFloorplanPanel );
 
 
 		JPanel statusPanel = new JPanel();
@@ -958,6 +958,7 @@ public class FTLFrame extends JFrame {
 	public void updateGameState( SavedGameParser.SavedGameState gs ) {
 
 		// savedGameDumpPanel doesn't modify anything.
+		savedGameFloorplanPanel.updateGameState( gs );
 		savedGameGeneralPanel.updateGameState( gs );
 
 		loadGameState(gs);

--- a/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
@@ -1,0 +1,232 @@
+package net.blerf.ftl.ui;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.HashMap;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import net.blerf.ftl.ui.RegexDocument;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FieldEditorPanel extends JPanel {
+	public enum ContentType { STRING, INTEGER, BOOLEAN, SLIDER };
+
+	private static final Logger log = LogManager.getLogger(SavedGameGeneralPanel.class);
+
+	private HashMap<String, JTextField> stringMap = new HashMap<String, JTextField>();
+	private HashMap<String, JTextField> intMap = new HashMap<String, JTextField>();
+	private HashMap<String, JCheckBox> boolMap = new HashMap<String, JCheckBox>();
+	private HashMap<String, JSlider> sliderMap = new HashMap<String, JSlider>();
+	private HashMap<String, JLabel> reminderMap = new HashMap<String, JLabel>();
+
+	private GridBagConstraints gridC = new GridBagConstraints();
+
+	private Component valueStrut = Box.createHorizontalStrut(120);
+	private Component reminderStrut = Box.createHorizontalStrut(90);
+
+	private boolean remindersVisible;
+
+	public FieldEditorPanel( boolean remindersVisible ) {
+		super( new GridBagLayout() );
+		this.remindersVisible = remindersVisible;
+
+		gridC.anchor = GridBagConstraints.WEST;
+		gridC.fill = GridBagConstraints.HORIZONTAL;
+		gridC.weightx = 0.0;
+		gridC.weighty = 0.0;
+		gridC.gridwidth = 1;
+		gridC.gridx = 0;
+		gridC.gridy = 0;
+
+		// No default width for col 0.
+		gridC.gridx = 0;
+		this.add( Box.createVerticalStrut(1), gridC );
+		gridC.gridx++;
+		this.add( valueStrut, gridC );
+		gridC.gridx++;
+		if ( remindersVisible ) {
+			this.add( reminderStrut, gridC );
+			gridC.gridy++;
+		}
+
+		gridC.insets = new Insets(2, 4, 2, 4);
+	}
+
+	public void setValueWidth( int width ) {
+		valueStrut.setMinimumSize( new Dimension(width, 0) );
+		valueStrut.setPreferredSize( new Dimension(width, 0) );
+	}
+
+	public void setReminderWidth( int width ) {
+		reminderStrut.setMinimumSize( new Dimension(width, 0) );
+		reminderStrut.setPreferredSize( new Dimension(width, 0) );
+	}
+
+	/**
+	 * Constructs JComponents for a given type of value.
+	 * A row consists of a static label, some JComponent,
+	 * and a reminder label.
+	 *
+	 * The component and reminder will be accessable later
+	 * via getter methods.
+	 */
+	public void addRow( String valueName, ContentType contentType ) {
+		gridC.fill = GridBagConstraints.HORIZONTAL;
+		gridC.gridwidth = 1;
+		gridC.gridx = 0;
+		this.add( new JLabel( valueName +":" ), gridC );
+
+		gridC.gridx++;
+		if ( contentType == ContentType.STRING ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JTextField valueField = new JTextField();
+			stringMap.put( valueName, valueField );
+			this.add( valueField, gridC );
+		}
+		else if ( contentType == ContentType.INTEGER ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JTextField valueField = new JTextField();
+			valueField.setHorizontalAlignment( JTextField.RIGHT );
+			valueField.setDocument( new RegexDocument("[0-9]*") );
+			intMap.put( valueName, valueField );
+			this.add( valueField, gridC );
+		}
+		else if ( contentType == ContentType.BOOLEAN ) {
+			gridC.anchor = GridBagConstraints.CENTER;
+			JCheckBox valueCheck = new JCheckBox();
+			valueCheck.setHorizontalAlignment( SwingConstants.CENTER );
+			boolMap.put( valueName, valueCheck );
+			this.add( valueCheck, gridC );
+		}
+		else if ( contentType == ContentType.SLIDER ) {
+			gridC.anchor = GridBagConstraints.CENTER;
+			JPanel panel = new JPanel();
+			panel.setLayout( new BoxLayout(panel, BoxLayout.X_AXIS) );
+			final JSlider valueSlider = new JSlider( JSlider.HORIZONTAL );
+			valueSlider.setPreferredSize( new Dimension(50, valueSlider.getPreferredSize().height) );
+			sliderMap.put( valueName, valueSlider );
+			panel.add(valueSlider);
+			final JTextField valueField = new JTextField(3);
+			valueField.setMaximumSize( valueField.getPreferredSize() );
+			valueField.setHorizontalAlignment( JTextField.RIGHT );
+			valueField.setEditable( false );
+			panel.add(valueField);
+			this.add( panel, gridC );
+
+			valueSlider.addChangeListener(new ChangeListener() {
+				@Override
+				public void stateChanged(ChangeEvent e) {
+					valueField.setText( ""+valueSlider.getValue() );
+				}
+			});
+		}
+		gridC.gridx++;
+
+		if ( remindersVisible ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JLabel valueReminder = new JLabel();
+			reminderMap.put( valueName, valueReminder );
+			this.add( valueReminder, gridC );
+		}
+
+		gridC.gridy++;
+	}
+
+	public void addBlankRow() {
+		gridC.fill = GridBagConstraints.NONE;
+		gridC.weighty = 0.0;
+		gridC.gridwidth = GridBagConstraints.REMAINDER;
+		gridC.gridx = 0;
+
+		this.add(Box.createVerticalStrut(12), gridC);
+		gridC.gridy++;
+	}
+
+	public void setStringAndReminder( String valueName, String s ) {
+		JTextField valueField = stringMap.get( valueName );
+		if ( valueField != null ) valueField.setText(s);
+		if ( remindersVisible ) setReminder( valueName, s );
+	}
+
+	public void setIntAndReminder( String valueName, int n ) {
+		setIntAndReminder( valueName, n, ""+n );
+	}
+	public void setIntAndReminder( String valueName, int n, String s ) {
+		JTextField valueField = intMap.get( valueName );
+		if ( valueField != null ) valueField.setText( ""+n );
+		if ( remindersVisible ) setReminder( valueName, s );
+	}
+
+	public void setBoolAndReminder( String valueName, boolean b ) {
+		setBoolAndReminder( valueName, b, ""+b );
+	}
+	public void setBoolAndReminder( String valueName, boolean b, String s ) {
+		JCheckBox valueCheck = boolMap.get( valueName );
+		if ( valueCheck != null ) valueCheck.setSelected(b);
+		if ( remindersVisible ) setReminder( valueName, s );
+	}
+
+	public void setSliderAndReminder( String valueName, int n ) {
+		setSliderAndReminder( valueName, n, ""+n );
+	}
+	public void setSliderAndReminder( String valueName, int n, String s ) {
+		JSlider valueSlider = sliderMap.get( valueName );
+		if ( valueSlider != null ) valueSlider.setValue(n);
+		if ( remindersVisible ) setReminder( valueName, s );
+	}
+
+	public void setReminder( String valueName, String s ) {
+		JLabel valueReminder = reminderMap.get( valueName );
+		if ( valueReminder != null ) valueReminder.setText( "( "+ s +" )" );
+	}
+
+	public JTextField getString( String valueName ) {
+		return stringMap.get( valueName );
+	}
+
+	public JTextField getInt( String valueName ) {
+		return intMap.get( valueName );
+	}
+
+	public JCheckBox getBoolean( String valueName ) {
+		return boolMap.get( valueName );
+	}
+
+	public JSlider getSlider( String valueName ) {
+		return sliderMap.get( valueName );
+	}
+
+	public void reset() {
+		for (JTextField valueField : stringMap.values())
+			valueField.setText("");
+
+		for (JTextField valueField : intMap.values())
+			valueField.setText("");
+
+		for (JCheckBox valueCheck : boolMap.values())
+			valueCheck.setSelected(false);
+
+		for (JSlider valueSlider : sliderMap.values())
+			valueSlider.setValue(0);
+
+		for (JLabel valueReminder : reminderMap.values())
+			valueReminder.setText("");
+	}
+}

--- a/src/main/java/net/blerf/ftl/ui/RegexDocument.java
+++ b/src/main/java/net/blerf/ftl/ui/RegexDocument.java
@@ -1,0 +1,59 @@
+package net.blerf.ftl.ui;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.PlainDocument;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+
+/**
+ * When applied to a JTextField via setDocument(), you can only enter a limited set of characters.
+ */
+public class RegexDocument extends PlainDocument {
+	private boolean dontCheck = false;
+	private Pattern p = null;
+
+	public RegexDocument( String regex ) {
+		if ( regex == null || regex.length()==0 ) dontCheck = true;
+
+		try {
+			p = Pattern.compile(regex);
+		} catch (PatternSyntaxException e) {dontCheck = true;}
+	}
+
+	public RegexDocument() {
+		dontCheck = true;
+	}
+
+
+	public void insertString( int offs, String str, AttributeSet a ) throws BadLocationException {
+		if ( str == null ) return;
+
+		boolean proceed = true;
+
+		if ( dontCheck == false ) {
+			String tmp = super.getText(0, offs) + str + (super.getLength()>offs ? super.getText(offs,super.getLength()-offs) : "");
+			Matcher m = p.matcher(tmp);
+			proceed = m.matches();
+		}
+
+		if ( proceed == true ) super.insertString( offs, str, a );
+	}
+
+
+	public void remove( int offs, int len ) throws BadLocationException {
+		boolean proceed = true;
+
+		if ( dontCheck == false ) {
+			try {
+				String tmp = super.getText(0, offs) + (super.getLength()>(offs+len) ? super.getText(offs+len, super.getLength()-(offs+len)) : "");
+				Matcher m = p.matcher(tmp);
+				proceed = m.matches();
+			} catch (BadLocationException f) {}
+		}
+
+		if ( proceed == true ) super.remove( offs, len );
+	}
+}

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -57,10 +57,10 @@ public class SavedGameFloorplanPanel extends JLayeredPane {
 	private static final Integer BASE_LAYER = new Integer(10);
 	private static final Integer FLOOR_LAYER = new Integer(11);
 	private static final Integer OXYGEN_LAYER = new Integer(12);
-	private static final Integer SYSTEM_LAYER = new Integer(13);
-	private static final Integer BREACH_LAYER = new Integer(14);
-	private static final Integer FIRE_LAYER = new Integer(15);
-	private static final Integer WALL_LAYER = new Integer(20);
+	private static final Integer WALL_LAYER = new Integer(15);
+	private static final Integer SYSTEM_LAYER = new Integer(16);
+	private static final Integer BREACH_LAYER = new Integer(17);
+	private static final Integer FIRE_LAYER = new Integer(18);
 	private static final Integer DOOR_LAYER = new Integer(30);
 	private static final Integer CREW_LAYER = new Integer(40);
 	private static final int squareSize = 35, tileEdge = 1;

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -1,0 +1,717 @@
+package net.blerf.ftl.ui;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsConfiguration;
+import java.awt.Image;
+import java.awt.Point;
+import java.awt.Stroke;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.awt.image.RasterFormatException;
+import java.awt.image.RescaleOp;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JLayeredPane;
+import javax.swing.JPanel;
+
+import net.blerf.ftl.model.ShipLayout;
+import net.blerf.ftl.parser.DataManager;
+import net.blerf.ftl.parser.SavedGameParser;
+import net.blerf.ftl.ui.FTLFrame;
+import net.blerf.ftl.ui.StatusbarMouseListener;
+import net.blerf.ftl.xml.ShipBlueprint;
+import net.blerf.ftl.xml.ShipChassis;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class SavedGameFloorplanPanel extends JLayeredPane {
+
+	private static final Integer BASE_LAYER = new Integer(10);
+	private static final Integer FLOOR_LAYER = new Integer(11);
+	private static final Integer OXYGEN_LAYER = new Integer(12);
+	private static final Integer SYSTEM_LAYER = new Integer(13);
+	private static final Integer BREACH_LAYER = new Integer(14);
+	private static final Integer FIRE_LAYER = new Integer(15);
+	private static final Integer WALL_LAYER = new Integer(20);
+	private static final Integer DOOR_LAYER = new Integer(30);
+	private static final Integer CREW_LAYER = new Integer(40);
+	private static final int squareSize = 35, tileEdge = 1;
+	private static final Logger log = LogManager.getLogger(SavedGameFloorplanPanel.class);
+
+	private FTLFrame frame;
+
+	private ShipBlueprint shipBlueprint = null;
+	private ShipLayout shipLayout = null;
+	private ShipChassis shipChassis = null;
+	private String shipGfxBaseName = null;
+	private int originX=0, originY=0;
+	private ArrayList<DoorSprite> doorSprites = new ArrayList<DoorSprite>();
+	private ArrayList<SystemSprite> systemSprites = new ArrayList<SystemSprite>();
+	private ArrayList<BreachSprite> breachSprites = new ArrayList<BreachSprite>();
+	private ArrayList<FireSprite> fireSprites = new ArrayList<FireSprite>();
+	private ArrayList<CrewSprite> crewSprites = new ArrayList<CrewSprite>();
+
+	private JLabel baseLbl = null;
+	private JLabel floorLbl = null;
+	private JLabel oxygenLbl = null;
+	private JLabel wallLbl = null;
+	private JLabel crewLbl = null;
+
+	public SavedGameFloorplanPanel( FTLFrame frame ) {
+		this.frame = frame;
+
+		baseLbl = new JLabel();
+		baseLbl.setOpaque(false);
+		baseLbl.setBounds( 0, 0, 50, 50 );
+		this.add( baseLbl, BASE_LAYER );
+
+		floorLbl = new JLabel();
+		floorLbl.setOpaque(false);
+		floorLbl.setBounds( 0, 0, 50, 50 );
+		this.add( floorLbl, FLOOR_LAYER );
+
+		oxygenLbl = new JLabel();
+		oxygenLbl.setOpaque(false);
+		oxygenLbl.setBounds( 0, 0, 50, 50 );
+		this.add( oxygenLbl, OXYGEN_LAYER );
+
+		wallLbl = new JLabel();
+		wallLbl.setOpaque(false);
+		wallLbl.setBounds( 0, 0, 50, 50 );
+		this.add( wallLbl, WALL_LAYER );
+
+		this.setBackground( new Color(212, 208, 200) );
+		this.setOpaque(true);
+	}
+
+	public void setGameState( SavedGameParser.SavedGameState gameState ) {
+		String prevGfxBaseName = shipGfxBaseName;
+
+		SavedGameParser.ShipState shipState = gameState.getPlayerShipState();
+		shipBlueprint = DataManager.get().getShip( shipState.getShipBlueprintId() );
+		shipLayout = DataManager.get().getShipLayout( shipState.getShipLayoutId() );
+		shipChassis = DataManager.get().getShipChassis( shipState.getShipLayoutId() );
+		shipGfxBaseName = shipState.getShipGraphicsBaseName();
+		originX = shipChassis.getImageBounds().x * -1;
+		originY = shipChassis.getImageBounds().y * -1;
+
+		GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+		GraphicsDevice gs = ge.getDefaultScreenDevice();
+		GraphicsConfiguration gc = gs.getDefaultConfiguration();
+
+		for (DoorSprite doorSprite : doorSprites)
+			this.remove( doorSprite );
+		doorSprites.clear();
+
+		for (SystemSprite systemSprite : systemSprites)
+			this.remove( systemSprite );
+		systemSprites.clear();
+
+		for (BreachSprite breachSprite : breachSprites)
+			this.remove( breachSprite );
+		breachSprites.clear();
+
+		for (FireSprite fireSprite : fireSprites)
+			this.remove( fireSprite );
+		fireSprites.clear();
+
+		for (CrewSprite crewSprite : crewSprites)
+			this.remove( crewSprite );
+		crewSprites.clear();
+
+		if ( shipGfxBaseName != prevGfxBaseName ) {
+			InputStream in = null;
+			try {
+				in = DataManager.get().getResourceInputStream("img/ship/"+ shipGfxBaseName +"_base.png");
+				BufferedImage baseImage = ImageIO.read( in );
+				in.close();
+				baseLbl.setIcon( new ImageIcon(baseImage) );
+				baseLbl.setSize( new Dimension(baseImage.getWidth(), baseImage.getHeight()) );
+
+			} catch (IOException e) {
+				log.error( "Failed to load ship base image ("+ shipGfxBaseName +")", e );
+
+			} finally {
+				try {if (in != null) in.close();}
+				catch (IOException f) {}
+	    }
+
+			try {
+				in = DataManager.get().getResourceInputStream("img/ship/"+ shipGfxBaseName +"_floor.png");
+				BufferedImage floorImage = ImageIO.read( in );
+				in.close();
+				floorLbl.setIcon( new ImageIcon(floorImage) );
+				floorLbl.setSize( new Dimension(floorImage.getWidth(), floorImage.getHeight()) );
+
+			} catch (IOException e) {
+				log.error( "Failed to load ship floor image ("+ shipGfxBaseName +")", e );
+
+			} finally {
+				try {if (in != null) in.close();}
+				catch (IOException f) {}
+	    }
+
+			BufferedImage wallImage = gc.createCompatibleImage( floorLbl.getIcon().getIconWidth(), floorLbl.getIcon().getIconHeight(), Transparency.BITMASK );
+			Graphics2D wallG = (Graphics2D)wallImage.createGraphics();
+			drawWalls( wallG, originX, originY, shipState, shipLayout );
+			wallG.dispose();
+			wallLbl.setIcon( new ImageIcon(wallImage) );
+			wallLbl.setSize( new Dimension(wallImage.getWidth(), wallImage.getHeight()) );
+		}
+
+		BufferedImage oxygenImage = gc.createCompatibleImage( baseLbl.getIcon().getIconWidth(), baseLbl.getIcon().getIconHeight(), Transparency.BITMASK );
+		Graphics2D oxygenG = (Graphics2D)oxygenImage.createGraphics();
+		drawOxygen( oxygenG, originX, originY, shipState, shipLayout );
+		oxygenG.dispose();
+		oxygenLbl.setIcon( new ImageIcon(oxygenImage) );
+		oxygenLbl.setSize( new Dimension(oxygenImage.getWidth(), oxygenImage.getHeight()) );
+
+		// Associate systems' normal names with their image basenames.
+		HashMap<String, String> systemNames = new HashMap<String, String>();
+		systemNames.put( ShipBlueprint.SystemList.NAME_PILOT, "pilot" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_DOORS, "doors" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_SENSORS, "sensors" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_MEDBAY, "medbay" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_OXYGEN, "oxygen" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_SHIELDS, "shields" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_ENGINES, "engines" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_WEAPONS, "weapons" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_DRONE_CTRL, "drones" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_TELEPORTER, "teleporter" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_CLOAKING, "cloaking" );
+		systemNames.put( ShipBlueprint.SystemList.NAME_ARTILLERY, "artillery" );
+
+		for (Map.Entry<String, String> entry : systemNames.entrySet()) {
+			int[] roomIds = shipBlueprint.getSystemList().getRoomIdBySystemName( entry.getKey() );
+			if ( roomIds != null ) {
+				for (int i=0; i < roomIds.length; i++) {
+					EnumMap<ShipLayout.RoomInfo, Integer> roomInfoMap = shipLayout.getRoomInfo( roomIds[i] );
+					int roomLocX = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_X ).intValue();
+					int roomLocY = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_Y ).intValue();
+					int roomX = originX + squareSize * roomLocX;
+					int roomY = originY + squareSize * roomLocY;
+					int squaresH = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_H ).intValue();
+					int squaresV = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_V ).intValue();
+					int systemX = roomX + tileEdge + squaresH*squareSize/2;
+					int systemY = roomY + tileEdge + squaresV*squareSize/2;
+					addSystemSprite( systemX, systemY, entry.getValue() );
+				}
+			}
+		}
+
+		// Add breaches
+		for (Map.Entry<Point, Integer> entry : shipState.getBreachMap().entrySet()) {
+			int breachCoordX = entry.getKey().x-shipLayout.getOffsetX();
+			int breachCoordY = entry.getKey().y-shipLayout.getOffsetY();
+			int breachX = originX+tileEdge + breachCoordX*squareSize + squareSize/2;
+			int breachY = originY+tileEdge + breachCoordY*squareSize + squareSize/2;
+			addBreachSprite( breachX, breachY, entry.getValue().intValue() );
+		}
+
+		// Add fires.
+		for (int i=0; i < shipLayout.getRoomCount(); i++) {
+			EnumMap<ShipLayout.RoomInfo, Integer> roomInfoMap = shipLayout.getRoomInfo(i);
+			int roomLocX = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_X ).intValue();
+			int roomLocY = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_Y ).intValue();
+			int roomX = originX + squareSize * roomLocX;
+			int roomY = originY + squareSize * roomLocY;
+			int squaresH = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_H ).intValue();
+			int squaresV = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_V ).intValue();
+
+			SavedGameParser.RoomState roomState = shipState.getRoom(i);
+			for (int s=0; s < squaresH*squaresV; s++) {
+				int fireHealth = roomState.getSquare(s)[0];
+				if ( fireHealth > 0 ) {
+					int fireX = roomX+tileEdge + (s%squaresH)*squareSize + squareSize/2;
+					int fireY = roomY+tileEdge + (s/squaresH)*squareSize + squareSize/2;
+					addFireSprite( fireX, fireY, fireHealth );
+				}
+			}
+		}
+
+		// Add crew.
+		for (SavedGameParser.CrewState crewState : shipState.getCrewList()) {
+			EnumMap<ShipLayout.RoomInfo, Integer> roomInfoMap = shipLayout.getRoomInfo( crewState.getRoomId() );
+			int roomLocX = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_X ).intValue();
+			int roomLocY = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_Y ).intValue();
+			int roomX = originX + squareSize * roomLocX;
+			int roomY = originY + squareSize * roomLocY;
+			int squaresH = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_H ).intValue();
+			int squaresV = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_V ).intValue();
+
+			int crewX = roomX + tileEdge + (crewState.getRoomSquare()%squaresH)*squareSize + squareSize/2;
+			int crewY = roomY + tileEdge + (crewState.getRoomSquare()/squaresH)*squareSize + squareSize/2;
+			addCrewSprite( crewX, crewY, crewState.getRace(), crewState.getName() );
+		}
+
+		this.revalidate();
+		this.repaint();
+	}
+
+	private void addDoorSprite( int centerX, int centerY, int level, boolean vertical, boolean open ) {
+		int offsetX = 0, offsetY = 0, w = 35, h = 35;
+		InputStream in = null;
+		try {
+			in = DataManager.get().getResourceInputStream( "img/effects/door_sheet.png" );
+			BufferedImage bigImage = ImageIO.read(in);
+
+			BufferedImage[] closedImages = new BufferedImage[3];
+			BufferedImage[] openImages = new BufferedImage[3];
+
+			for (int i=0; i < openImages.length; i++) {
+				closedImages[i] = bigImage.getSubimage(offsetX, offsetY+i*h, w, h);
+				openImages[i] = bigImage.getSubimage(offsetX+4*w, offsetY+i*h, w, h);
+			}
+
+			DoorSprite doorSprite = new DoorSprite( closedImages, openImages, level, vertical, open );
+			doorSprite.setBounds( centerX-w/2, centerY-h/2, w, h );
+			doorSprites.add( doorSprite );
+			this.add( doorSprite, DOOR_LAYER );
+
+		} catch (RasterFormatException e) {
+			log.error( "Failed to load and crop door images (door_sheet)", e );
+		} catch (IOException e) {
+			log.error( "Failed to load and crop door images (door_sheet)", e );
+		} finally {
+			try {if (in != null) in.close();}
+			catch (IOException f) {}
+		}
+	}
+
+	private void addSystemSprite( int centerX, int centerY, String overlayBaseName ) {
+		InputStream in = null;
+		try {
+			in = DataManager.get().getResourceInputStream( "img/icons/s_"+ overlayBaseName +"_overlay.png" );
+			BufferedImage overlayImage = ImageIO.read(in);
+			int w = overlayImage.getWidth();
+			int h = overlayImage.getHeight();
+
+			// Darken the white icon to gray...
+			GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+			GraphicsDevice gs = ge.getDefaultScreenDevice();
+			GraphicsConfiguration gc = gs.getDefaultConfiguration();
+			BufferedImage canvas = gc.createCompatibleImage(w, h, BufferedImage.TYPE_INT_ARGB);
+			Graphics2D g2d = canvas.createGraphics();
+			g2d.drawImage(overlayImage, 0, 0, null);
+			g2d.dispose();
+			RescaleOp op = new RescaleOp(new float[] { 0.49f, 0.49f, 0.49f, 1f }, new float[] { 0, 0, 0, 0 }, null);
+			overlayImage = op.filter(canvas, null);
+
+			SystemSprite systemSprite = new SystemSprite( overlayImage );
+			systemSprite.setBounds( centerX-w/2, centerY-h/2, w, h );
+			systemSprites.add( systemSprite );
+			this.add( systemSprite, SYSTEM_LAYER );
+
+		} catch (IOException e) {
+			log.error( "Failed to load system overlay image ("+ overlayBaseName +")", e );
+		} finally {
+			try {if (in != null) in.close();}
+			catch (IOException f) {}
+		}
+	}
+
+	private void addBreachSprite( int centerX, int centerY, int health ) {
+		int offsetX = 0, offsetY = 0, w = 19, h = 19;
+		InputStream in = null;
+		try {
+			in = DataManager.get().getResourceInputStream( "img/effects/breach.png" );
+			BufferedImage bigImage = ImageIO.read(in);
+			BufferedImage breachImage = bigImage.getSubimage(offsetX+6*w, offsetY, w, h);
+
+			BreachSprite breachSprite = new BreachSprite( breachImage, health );
+			breachSprite.setBounds( centerX-w/2, centerY-h/2, w, h );
+			breachSprites.add( breachSprite );
+			this.add( breachSprite, BREACH_LAYER );
+
+		} catch (RasterFormatException e) {
+			log.error( "Failed to load and crop breach image (breach)", e );
+		} catch (IOException e) {
+			log.error( "Failed to load and crop breach image (breach)", e );
+		} finally {
+			try {if (in != null) in.close();}
+			catch (IOException f) {}
+		}
+	}
+
+	private void addFireSprite( int centerX, int centerY, int health ) {
+		int offsetX = 0, offsetY = 0, w = 32, h = 32;
+		InputStream in = null;
+		try {
+			in = DataManager.get().getResourceInputStream( "img/effects/fire_L1_strip8.png" );
+			BufferedImage bigImage = ImageIO.read(in);
+			BufferedImage fireImage = bigImage.getSubimage(offsetX, offsetY, w, h);
+
+			FireSprite fireSprite = new FireSprite( fireImage, health );
+			fireSprite.setBounds( centerX-w/2, centerY-h/2, w, h );
+			fireSprites.add( fireSprite );
+			this.add( fireSprite, FIRE_LAYER );
+
+		} catch (RasterFormatException e) {
+			log.error( "Failed to load and crop fire image (fire_L1_strip8)", e );
+		} catch (IOException e) {
+			log.error( "Failed to load and crop fire image (fire_L1_strip8)", e );
+		} finally {
+			try {if (in != null) in.close();}
+			catch (IOException f) {}
+		}
+	}
+
+	private void addCrewSprite( int centerX, int centerY, String race, String name ) {
+		int offsetX = 0, offsetY = 0, w = 35, h = 35;
+		InputStream in = null;
+		try {
+			in = DataManager.get().getResourceInputStream( "img/people/"+ race +"_player_yellow.png" );
+			BufferedImage bigImage = ImageIO.read(in);
+			BufferedImage crewImage = bigImage.getSubimage(offsetX, offsetY, w, h);
+
+			CrewSprite crewSprite = new CrewSprite( crewImage );
+			crewSprite.setBounds( centerX-w/2, centerY-h/2, w, h );
+			crewSprites.add( crewSprite );
+			this.add( crewSprite, CREW_LAYER );
+			crewSprite.addMouseListener( new StatusbarMouseListener(frame, name) );
+
+		} catch (RasterFormatException e) {
+			log.error( "Failed to load and crop race image ("+ race +")", e );
+		} catch (IOException e) {
+			log.error( "Failed to load and crop race image ("+ race +")", e );
+		} finally {
+			try {if (in != null) in.close();}
+			catch (IOException f) {}
+		}
+	}
+
+	/** Relocates a JComponent within its parent's space. */
+	private void placeSprite( int centerX, int centerY, JComponent sprite ) {
+		Dimension spriteSize = sprite.getSize();
+		sprite.setLocation( centerX-spriteSize.width/2, centerY-spriteSize.height/2 );
+	}
+
+	/** Draws each room's walls, door openings, and floor crevices. */
+	private void drawWalls( Graphics2D wallG, int originX, int originY, SavedGameParser.ShipState shipState, ShipLayout shipLayout ) {
+		int doorLevel = shipState.getSystem("Doors").getCapacity()-1;  // Convert to 0-based.
+
+		Color prevColor = wallG.getColor();
+		Stroke prevStroke = wallG.getStroke();
+		Color floorCrackColor = new Color(125, 125, 125);
+		Stroke floorCrackStroke = new BasicStroke(1);
+		Color roomBorderColor = new Color(15, 15, 15);
+		Stroke roomBorderStroke = new BasicStroke(3);
+		Color closedDoorColor = new Color(250, 150, 50);
+		Stroke closedDoorStroke = new BasicStroke(5);
+		SavedGameParser.DoorState doorState = null;
+		int fromX, fromY, toX, toY;
+
+		for (int i=0; i < shipLayout.getRoomCount(); i++) {
+			EnumMap<ShipLayout.RoomInfo, Integer> roomInfoMap = shipLayout.getRoomInfo(i);
+			int roomLocX = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_X ).intValue();
+			int roomLocY = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_Y ).intValue();
+			int roomX = originX + squareSize * roomLocX;
+			int roomY = originY + squareSize * roomLocY;
+			int squaresH = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_H ).intValue();
+			int squaresV = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_V ).intValue();
+
+			// Draw floor lines within rooms.
+			wallG.setColor( floorCrackColor );
+			wallG.setStroke( floorCrackStroke );
+			for (int n=1; n <= squaresV-1; n++)  // H lines.
+				wallG.drawLine( roomX+1, roomY+n*squareSize, roomX+squaresH*squareSize-1, roomY+n*squareSize );
+			for (int n=1; n <= squaresH-1; n++)  // V lines.
+				wallG.drawLine( roomX+n*squareSize, roomY+1, roomX+n*squareSize, roomY+squaresV*squareSize-1 );
+
+			// Draw borders around rooms.
+			for (int n=1; n <= squaresV; n++) {  // V lines.
+				// West side.
+				fromX = roomX;
+				fromY = roomY+(n-1)*squareSize;
+				toX = roomX;
+				toY = roomY+n*squareSize;
+				doorState = shipState.getDoor(roomLocX, roomLocY+n-1, 1);
+				if ( doorState != null ) {  // Must be a door there.
+					// Draw stubs around door.
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, toX, fromY+(toY-fromY)/8 );
+				  wallG.drawLine( fromX, fromY+(toY-fromY)/8*7, toX, toY );
+
+					addDoorSprite( fromX+tileEdge, fromY+tileEdge+(toY-fromY)/2, doorLevel, true, doorState.isOpen() );
+				} else {
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, toX, toY );
+				}
+
+				// East Side.
+				fromX = roomX+squaresH*squareSize;
+				fromY = roomY+(n-1)*squareSize;
+				toX = roomX+squaresH*squareSize;
+				toY = roomY+n*squareSize;
+				doorState = shipState.getDoor(roomLocX+squaresH, roomLocY+n-1, 1);
+				if ( doorState != null ) {  // Must be a door there.
+					// Draw stubs around door.
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, toX, fromY+(toY-fromY)/8 );
+				  wallG.drawLine( fromX, fromY+(toY-fromY)/8*7, toX, toY );
+
+					addDoorSprite( fromX+tileEdge, fromY+tileEdge+(toY-fromY)/2, doorLevel, true, doorState.isOpen() );
+				} else {
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, toX, toY );
+				}
+			}
+
+			wallG.setStroke( roomBorderStroke );
+			wallG.setColor( roomBorderColor );
+			for (int n=1; n <= squaresH; n++) {  // H lines.
+				// North side.
+				fromX = roomX+(n-1)*squareSize;
+				fromY = roomY;
+				toX = roomX+n*squareSize;
+				toY = roomY;
+				doorState = shipState.getDoor(roomLocX+n-1, roomLocY, 0);
+				if ( doorState != null ) {  // Must be a door there.
+					// Draw stubs around door.
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, fromX+(toX-fromX)/8, fromY );
+				  wallG.drawLine( fromX+(toX-fromX)/8*7, fromY, toX, toY );
+
+					addDoorSprite( fromX+tileEdge+(toX-fromX)/2, fromY+tileEdge, doorLevel, false, doorState.isOpen() );
+				} else {
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, toX, toY );
+				}
+
+				// South side.
+				fromX = roomX+(n-1)*squareSize;
+				fromY = roomY+squaresV*squareSize;
+				toX = roomX+n*squareSize;
+				toY = roomY+squaresV*squareSize;
+				doorState = shipState.getDoor(roomLocX+n-1, roomLocY+squaresV, 0);
+				if ( doorState != null ) {  // Must be a door there.
+					// Draw stubs around door.
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, fromX+(toX-fromX)/8, fromY );
+				  wallG.drawLine( fromX+(toX-fromX)/8*7, fromY, toX, toY );
+
+					addDoorSprite( fromX+tileEdge+(toX-fromX)/2, fromY+tileEdge, doorLevel, false, doorState.isOpen() );
+				} else {
+					wallG.setStroke( roomBorderStroke );
+					wallG.setColor( roomBorderColor );
+				  wallG.drawLine( fromX, fromY, toX, toY );
+				}
+			}
+		}
+		wallG.setColor( prevColor );
+		wallG.setStroke( prevStroke );
+	}
+
+	/** Draws each room in shades of red to indicate oxygen levels. */
+	private void drawOxygen( Graphics2D oxygenG, int originX, int originY, SavedGameParser.ShipState shipState, ShipLayout shipLayout ) {
+		Color prevColor = oxygenG.getColor();
+		Stroke prevStroke = oxygenG.getStroke();
+		Color maxColor = new Color( 230, 226, 219 );
+		Color minColor = new Color( 255, 176, 169 );
+		Color vacuumBorderColor = new Color(255, 180, 0);
+
+		for (int i=0; i < shipLayout.getRoomCount(); i++) {
+			EnumMap<ShipLayout.RoomInfo, Integer> roomInfoMap = shipLayout.getRoomInfo(i);
+			int roomLocX = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_X ).intValue();
+			int roomLocY = roomInfoMap.get( ShipLayout.RoomInfo.LOCATION_Y ).intValue();
+			int roomX = originX + squareSize * roomLocX;
+			int roomY = originY + squareSize * roomLocY;
+			int squaresH = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_H ).intValue();
+			int squaresV = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_V ).intValue();
+			int oxygen = shipState.getRoom(i).getOxygen();
+
+			if ( oxygen == 100 ) {
+				oxygenG.setColor( maxColor );
+			} else if ( oxygen == 0 ) {
+				oxygenG.setColor( minColor );
+			} else {
+				int p = oxygen / 100;
+				int maxRed = maxColor.getRed();
+				int maxGreen = maxColor.getGreen();
+				int maxBlue = maxColor.getBlue();
+				int minRed = minColor.getRed();
+				int minGreen = minColor.getGreen();
+				int minBlue = minColor.getBlue();
+				Color partialColor = new Color( minRed+p*(maxRed-minRed), minGreen+p*(maxGreen-minGreen), minBlue+p*(maxBlue-minBlue) );
+				oxygenG.setColor( partialColor );
+			}
+			oxygenG.fillRect( roomX, roomY, squaresH*squareSize, squaresV*squareSize );
+
+			if ( oxygen == 0 ) {  // Draw the yellow border.
+				oxygenG.setColor( vacuumBorderColor );
+				oxygenG.drawRect( roomX+2, roomY+2, squaresH*squareSize-4, squaresV*squareSize-4 );
+				oxygenG.drawRect( roomX+3, roomY+3, squaresH*squareSize-6, squaresV*squareSize-6 );
+			}
+		}
+
+		oxygenG.setColor( prevColor );
+		oxygenG.setStroke( prevStroke );
+	}
+
+
+
+	public class DoorSprite extends JComponent {
+		private BufferedImage[] closedImages;
+		private BufferedImage[] openImages;
+		private int level;
+		private boolean vertical;
+		private boolean open;
+
+		public DoorSprite( BufferedImage[] closedImages, BufferedImage[] openImages, int level, boolean vertical, boolean open ) {
+			this.closedImages = closedImages;
+			this.openImages = openImages;
+			this.level = level;
+			this.vertical = vertical;
+			this.open = open;
+			this.setOpaque(false);
+		}
+
+		public void setLevel( int n ) { level = n; }
+		public int getLevel() { return level; }
+		public void setVertical( boolean b ) { vertical = b; }
+		public boolean isVertical() { return vertical; }
+		public void setOpen( boolean b ) { open = b; }
+		public boolean isOpen() { return open; }
+
+		@Override
+		public void paintComponent( Graphics g ) {
+			super.paintComponent(g);
+
+			Graphics2D g2d = (Graphics2D)g;
+			int w = this.getSize().width, h = this.getSize().height;
+
+			if ( !vertical ) {  // Use rotated coordinates to draw AS IF vertical.
+				g2d.rotate( Math.toRadians(90) );   // Clockwise.
+				w = this.getSize().height; h = this.getSize().width;
+				g2d.translate( 0, -(h-1) );
+				//g2d.translate( (w-1)/2, (h-1)/2 );  // Down+Right (Right+Up in that perspective).
+			}
+
+			BufferedImage doorImage;
+			if ( open )
+				doorImage = openImages[level];
+			else
+				doorImage = closedImages[level];
+
+			g2d.drawImage( doorImage, 0, 0, this.getWidth()-1, this.getHeight()-1, this);
+		}
+	}
+
+
+
+	public class SystemSprite extends JComponent {
+		private BufferedImage overlayImage;
+
+		public SystemSprite( BufferedImage overlayImage ) {
+			this.overlayImage = overlayImage;
+			this.setOpaque(false);
+		}
+
+		@Override
+		public void paintComponent( Graphics g ) {
+			super.paintComponent(g);
+
+			Graphics2D g2d = (Graphics2D)g;
+			g2d.drawImage( overlayImage, 0, 0, this.getWidth()-1, this.getHeight()-1, this);
+		}
+	}
+
+
+
+	public class BreachSprite extends JComponent {
+		private BufferedImage breachImage;
+		private int health;
+
+		public BreachSprite( BufferedImage breachImage, int health ) {
+			this.breachImage = breachImage;
+			this.health = health;
+			this.setOpaque(false);
+		}
+
+		public void setHealth( int n ) { health = n; }
+		public int getHealth() { return health; }
+
+		@Override
+		public void paintComponent( Graphics g ) {
+			super.paintComponent(g);
+
+			Graphics2D g2d = (Graphics2D)g;
+			g2d.drawImage( breachImage, 0, 0, this.getWidth()-1, this.getHeight()-1, this);
+		}
+	}
+
+
+
+	public class FireSprite extends JComponent {
+		private BufferedImage fireImage;
+		private int health;
+
+		public FireSprite( BufferedImage fireImage, int health ) {
+			this.fireImage = fireImage;
+			this.health = health;
+			this.setOpaque(false);
+		}
+
+		public void setHealth( int n ) { health = n; }
+		public int getHealth() { return health; }
+
+		@Override
+		public void paintComponent( Graphics g ) {
+			super.paintComponent(g);
+
+			Graphics2D g2d = (Graphics2D)g;
+			g2d.drawImage( fireImage, 0, 0, this.getWidth()-1, this.getHeight()-1, this);
+		}
+	}
+
+
+
+	public class CrewSprite extends JComponent {
+		private BufferedImage crewImage;
+
+		public CrewSprite( BufferedImage crewImage ) {
+			this.crewImage = crewImage;
+			this.setOpaque(false);
+		}
+
+		@Override
+		public void paintComponent( Graphics g ) {
+			super.paintComponent(g);
+
+			Graphics2D g2d = (Graphics2D)g;
+			g2d.drawImage( crewImage, 0, 0, this.getWidth()-1, this.getHeight()-1, this);
+		}
+	}
+}

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -299,7 +299,7 @@ public class SavedGameFloorplanPanel extends JLayeredPane {
 
 			int crewX = roomX + tileEdge + (crewState.getRoomSquare()%squaresH)*squareSize + squareSize/2;
 			int crewY = roomY + tileEdge + (crewState.getRoomSquare()/squaresH)*squareSize + squareSize/2;
-			addCrewSprite( crewX, crewY, crewState.getRace(), crewState.getName() );
+			addCrewSprite( crewX, crewY, crewState.getRace(), crewState.getName(), crewState.isPlayerControlled(), crewState.isEnemyBoardingDrone() );
 		}
 
 		this.revalidate();
@@ -414,11 +414,20 @@ public class SavedGameFloorplanPanel extends JLayeredPane {
 		}
 	}
 
-	private void addCrewSprite( int centerX, int centerY, String race, String name ) {
+	private void addCrewSprite( int centerX, int centerY, String race, String name, boolean playerControlled, boolean enemyBoardingDrone ) {
 		int offsetX = 0, offsetY = 0, w = 35, h = 35;
+		String suffix = "";
 		InputStream in = null;
 		try {
-			in = DataManager.get().getResourceInputStream( "img/people/"+ race +"_player_yellow.png" );
+			if ( enemyBoardingDrone ) {
+				race = "battle";
+				suffix = "_enemy_sheet";
+			} else if ( playerControlled ) {
+				suffix = "_player_yellow";
+			} else {
+				suffix = "_enemy_red";
+			}
+			in = DataManager.get().getResourceInputStream( "img/people/"+ race + suffix +".png" );
 			BufferedImage bigImage = ImageIO.read(in);
 			BufferedImage crewImage = bigImage.getSubimage(offsetX, offsetY, w, h);
 
@@ -429,9 +438,9 @@ public class SavedGameFloorplanPanel extends JLayeredPane {
 			crewSprite.addMouseListener( new StatusbarMouseListener(frame, name) );
 
 		} catch (RasterFormatException e) {
-			log.error( "Failed to load and crop race image ("+ race +")", e );
+			log.error( "Failed to load and crop race image ("+ race + suffix +")", e );
 		} catch (IOException e) {
-			log.error( "Failed to load and crop race image ("+ race +")", e );
+			log.error( "Failed to load and crop race image ("+ race + suffix +")", e );
 		} finally {
 			try {if (in != null) in.close();}
 			catch (IOException f) {}

--- a/src/main/java/net/blerf/ftl/ui/SavedGameGeneralPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameGeneralPanel.java
@@ -42,8 +42,7 @@ public class SavedGameGeneralPanel extends JPanel {
 	private static final Logger log = LogManager.getLogger(SavedGameGeneralPanel.class);
 
 	private static final String SHIP_NAME="Ship Name", HULL="Hull", FUEL="Fuel", DRONE_PARTS="Drone Parts",
-	                            MISSILES="Missiles", SCRAP="Scrap", HAZARDS_VISIBLE="Sector Hazards Visible",
-	                            FULL_OXYGEN="Full Oxygen", NO_BREACHES="No Breaches", NO_FIRES="No Fires";
+	                            MISSILES="Missiles", SCRAP="Scrap", HAZARDS_VISIBLE="Sector Hazards Visible";
 
 	private FTLFrame frame;
 
@@ -88,15 +87,8 @@ public class SavedGameGeneralPanel extends JPanel {
 		addRow( contentPane, SCRAP, ContentType.INTEGER, gridC );
 		addRow( contentPane, HAZARDS_VISIBLE, ContentType.BOOLEAN, gridC );
 		addBlankRow( contentPane, gridC );
-		addRow( contentPane, FULL_OXYGEN, ContentType.BOOLEAN, gridC );
-		addRow( contentPane, NO_BREACHES, ContentType.BOOLEAN, gridC );
-		addRow( contentPane, NO_FIRES, ContentType.BOOLEAN, gridC );
-		addBlankRow( contentPane, gridC );
 
 		boolMap.get(HAZARDS_VISIBLE).addMouseListener( new StatusbarMouseListener(frame, "Show hazards on the current sector map.") );
-		boolMap.get(FULL_OXYGEN).addMouseListener( new StatusbarMouseListener(frame, "Set all rooms' oxygen to 100%.") );
-		boolMap.get(NO_BREACHES).addMouseListener( new StatusbarMouseListener(frame, "Remove all hull breaches.") );
-		boolMap.get(NO_FIRES).addMouseListener( new StatusbarMouseListener(frame, "Remove all fires.") );
 
 		GridBagConstraints thisC = new GridBagConstraints();
 		thisC.fill = GridBagConstraints.NONE;
@@ -248,22 +240,6 @@ public class SavedGameGeneralPanel extends JPanel {
 			setStringAndReminder( MISSILES, ""+shipState.getMissilesAmt() );
 			setStringAndReminder( SCRAP, ""+shipState.getScrapAmt() );
 			setBoolAndReminder( HAZARDS_VISIBLE, gameState.areSectorHazardsVisible() );
-
-			int meanOxygen = 0;
-			int breachCount = shipState.getBreachMap().size();
-			int fireCount = 0;
-			for (SavedGameParser.RoomState room : shipState.getRoomList()) {
-				meanOxygen += room.getOxygen();
-
-				for (int[] square : room.getSquareList()) {
-					if ( square[0] > 0 ) fireCount++;
-				}
-			}
-			meanOxygen = Math.round( meanOxygen / ((float)shipState.getRoomList().size()) );
-
-			setBoolAndReminder( FULL_OXYGEN, (meanOxygen == 100), meanOxygen +"%" );
-			setBoolAndReminder( NO_BREACHES, (breachCount == 0), ""+breachCount );
-			setBoolAndReminder( NO_FIRES, (fireCount == 0), ""+fireCount );
 		}
 
 		this.repaint();
@@ -298,23 +274,5 @@ public class SavedGameGeneralPanel extends JPanel {
 		catch (NumberFormatException e) {}
 
 		gameState.setSectorHazardsVisible( boolMap.get(HAZARDS_VISIBLE).isSelected() );
-
-		boolean fullOxygen = boolMap.get(FULL_OXYGEN).isSelected();
-		boolean noBreaches = boolMap.get(NO_BREACHES).isSelected();
-		boolean noFires = boolMap.get(NO_FIRES).isSelected();
-
-		if ( noBreaches ) shipState.getBreachMap().clear();
-
-		for (SavedGameParser.RoomState room : shipState.getRoomList()) {
-			if ( fullOxygen ) room.setOxygen(100);
-
-			if ( noFires ) {
-				for (int[] square : room.getSquareList()) {
-					square[0] = 0;
-					square[1] = 0;
-					// TODO: Determine if the square's third value is relevant.
-				}
-			}
-		}
 	}
 }

--- a/src/main/java/net/blerf/ftl/ui/SavedGameGeneralPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameGeneralPanel.java
@@ -259,7 +259,7 @@ public class SavedGameGeneralPanel extends JPanel {
 					if ( square[0] > 0 ) fireCount++;
 				}
 			}
-			meanOxygen /= shipState.getRoomList().size();
+			meanOxygen = Math.round( meanOxygen / ((float)shipState.getRoomList().size()) );
 
 			setBoolAndReminder( FULL_OXYGEN, (meanOxygen == 100), meanOxygen +"%" );
 			setBoolAndReminder( NO_BREACHES, (breachCount == 0), ""+breachCount );

--- a/src/main/java/net/blerf/ftl/ui/SavedGameGeneralPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameGeneralPanel.java
@@ -1,0 +1,320 @@
+package net.blerf.ftl.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import net.blerf.ftl.parser.DataManager;
+import net.blerf.ftl.parser.SavedGameParser;
+import net.blerf.ftl.ui.FTLFrame;
+import net.blerf.ftl.ui.RegexDocument;
+import net.blerf.ftl.ui.StatusbarMouseListener;
+import net.blerf.ftl.xml.ShipBlueprint;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class SavedGameGeneralPanel extends JPanel {
+	private enum ContentType { STRING, INTEGER, BOOLEAN, SLIDER };
+
+	private static final Logger log = LogManager.getLogger(SavedGameGeneralPanel.class);
+
+	private static final String SHIP_NAME="Ship Name", HULL="Hull", FUEL="Fuel", DRONE_PARTS="Drone Parts",
+	                            MISSILES="Missiles", SCRAP="Scrap", HAZARDS_VISIBLE="Sector Hazards Visible",
+	                            FULL_OXYGEN="Full Oxygen", NO_BREACHES="No Breaches", NO_FIRES="No Fires";
+
+	private FTLFrame frame;
+
+	private HashMap<String, JTextField> stringMap = new HashMap<String, JTextField>();
+	private HashMap<String, JCheckBox> boolMap = new HashMap<String, JCheckBox>();
+	private HashMap<String, JSlider> sliderMap = new HashMap<String, JSlider>();
+	private HashMap<String, JLabel> reminderMap = new HashMap<String, JLabel>();
+
+	public SavedGameGeneralPanel( FTLFrame frame ) {
+		this.setLayout( new GridBagLayout() );
+
+		this.frame = frame;
+
+		GridBagConstraints gridC = new GridBagConstraints();
+		gridC.anchor = GridBagConstraints.WEST;
+		gridC.fill = GridBagConstraints.HORIZONTAL;
+		gridC.weightx = 0.0;
+		gridC.weighty = 0.0;
+		gridC.gridwidth = 1;
+		gridC.gridx = 0;
+		gridC.gridy = 0;
+
+		JPanel contentPane = new JPanel( new GridBagLayout() );
+		contentPane.setBorder( BorderFactory.createTitledBorder("General") );
+
+		// No default width for col 0.
+		gridC.gridx = 0;
+		contentPane.add( Box.createVerticalStrut(1), gridC );
+		gridC.gridx++;
+		contentPane.add( Box.createHorizontalStrut(120), gridC );
+		gridC.gridx++;
+		contentPane.add( Box.createHorizontalStrut(90), gridC );
+		gridC.gridy++;
+
+		gridC.insets = new Insets(2, 4, 2, 4);
+		addBlankRow( contentPane, gridC );
+		addRow( contentPane, SHIP_NAME, ContentType.STRING, gridC );
+		addRow( contentPane, HULL, ContentType.SLIDER, gridC );
+		addRow( contentPane, FUEL, ContentType.INTEGER, gridC );
+		addRow( contentPane, DRONE_PARTS, ContentType.INTEGER, gridC );
+		addRow( contentPane, MISSILES, ContentType.INTEGER, gridC );
+		addRow( contentPane, SCRAP, ContentType.INTEGER, gridC );
+		addRow( contentPane, HAZARDS_VISIBLE, ContentType.BOOLEAN, gridC );
+		addBlankRow( contentPane, gridC );
+		addRow( contentPane, FULL_OXYGEN, ContentType.BOOLEAN, gridC );
+		addRow( contentPane, NO_BREACHES, ContentType.BOOLEAN, gridC );
+		addRow( contentPane, NO_FIRES, ContentType.BOOLEAN, gridC );
+		addBlankRow( contentPane, gridC );
+
+		boolMap.get(HAZARDS_VISIBLE).addMouseListener( new StatusbarMouseListener(frame, "Show hazards on the current sector map.") );
+		boolMap.get(FULL_OXYGEN).addMouseListener( new StatusbarMouseListener(frame, "Set all rooms' oxygen to 100%.") );
+		boolMap.get(NO_BREACHES).addMouseListener( new StatusbarMouseListener(frame, "Remove all hull breaches.") );
+		boolMap.get(NO_FIRES).addMouseListener( new StatusbarMouseListener(frame, "Remove all fires.") );
+
+		GridBagConstraints thisC = new GridBagConstraints();
+		thisC.fill = GridBagConstraints.NONE;
+		thisC.weightx = 0.0;
+		thisC.weighty = 0.0;
+		thisC.gridx = 0;
+		thisC.gridy = 0;
+		this.add( contentPane, thisC );
+
+		thisC.fill = GridBagConstraints.BOTH;
+		thisC.weighty = 1.0;
+		thisC.gridx = 0;
+		thisC.gridy++;
+		this.add( Box.createVerticalGlue(), thisC );
+
+		setGameState( null );
+	}
+
+	/**
+	 * Constructs JComponents for a given type of value.
+	 * A row consists of a static label, some JComponent, and a reminder label.
+	 * The last two will be accessable later via Maps.
+	 */
+	private void addRow( JPanel parent, String valueName, ContentType contentType, GridBagConstraints gridC ) {
+		gridC.fill = GridBagConstraints.HORIZONTAL;
+		gridC.gridwidth = 1;
+		gridC.gridx = 0;
+		parent.add( new JLabel( valueName +":" ), gridC );
+
+		gridC.gridx++;
+		if ( contentType == ContentType.STRING ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JTextField valueField = new JTextField();
+			stringMap.put( valueName, valueField );
+			parent.add( valueField, gridC );
+		}
+		else if ( contentType == ContentType.INTEGER ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JTextField valueField = new JTextField();
+			valueField.setHorizontalAlignment( JTextField.RIGHT );
+			valueField.setDocument( new RegexDocument("[0-9]*") );
+			stringMap.put( valueName, valueField );
+			parent.add( valueField, gridC );
+		}
+		else if ( contentType == ContentType.BOOLEAN ) {
+			gridC.anchor = GridBagConstraints.CENTER;
+			JCheckBox valueCheck = new JCheckBox();
+			valueCheck.setHorizontalAlignment( SwingConstants.CENTER );
+			boolMap.put( valueName, valueCheck );
+			parent.add( valueCheck, gridC );
+		}
+		else if ( contentType == ContentType.SLIDER ) {
+			gridC.anchor = GridBagConstraints.CENTER;
+			JPanel panel = new JPanel();
+			panel.setLayout( new BoxLayout(panel, BoxLayout.X_AXIS) );
+			final JSlider valueSlider = new JSlider( JSlider.HORIZONTAL );
+			valueSlider.setPreferredSize( new Dimension(50, valueSlider.getPreferredSize().height) );
+			sliderMap.put( valueName, valueSlider );
+			panel.add(valueSlider);
+			final JTextField valueField = new JTextField(3);
+			valueField.setMaximumSize( valueField.getPreferredSize() );
+			valueField.setHorizontalAlignment( JTextField.RIGHT );
+			valueField.setEditable( false );
+			panel.add(valueField);
+			parent.add( panel, gridC );
+
+			valueSlider.addChangeListener(new ChangeListener() {
+				@Override
+				public void stateChanged(ChangeEvent e) {
+					valueField.setText( ""+valueSlider.getValue() );
+				}
+			});
+		}
+
+		gridC.anchor = GridBagConstraints.WEST;
+		gridC.gridx++;
+		JLabel valueReminder = new JLabel();
+		reminderMap.put( valueName, valueReminder );
+		parent.add( valueReminder, gridC );
+
+		gridC.gridy++;
+	}
+
+	public void addBlankRow( JPanel parent, GridBagConstraints gridC ) {
+		gridC.fill = GridBagConstraints.NONE;
+		gridC.weighty = 0.0;
+		gridC.gridwidth = GridBagConstraints.REMAINDER;
+		gridC.gridx = 0;
+
+		parent.add(Box.createVerticalStrut(12), gridC);
+		gridC.gridy++;
+	}
+
+	private void setStringAndReminder( String valueName, String s ) {
+		JTextField valueField = stringMap.get( valueName );
+		if ( valueField != null ) valueField.setText(s);
+		setReminder( valueName, s );
+	}
+
+	private void setBoolAndReminder( String valueName, boolean b ) {
+		setBoolAndReminder( valueName, b, ""+b );
+	}
+	private void setBoolAndReminder( String valueName, boolean b, String s ) {
+		JCheckBox valueCheck = boolMap.get( valueName );
+		if ( valueCheck != null ) valueCheck.setSelected(b);
+		setReminder( valueName, s );
+	}
+
+	private void setSliderAndReminder( String valueName, int n ) {
+		setSliderAndReminder( valueName, n, ""+n );
+	}
+	private void setSliderAndReminder( String valueName, int n, String s ) {
+		JSlider valueSlider = sliderMap.get( valueName );
+		if ( valueSlider != null ) valueSlider.setValue(n);
+		setReminder( valueName, s );
+	}
+
+	private void setReminder( String valueName, String s ) {
+		JLabel valueReminder = reminderMap.get( valueName );
+		if ( valueReminder != null ) valueReminder.setText( "( "+ s +" )" );
+	}
+
+	public void setGameState( SavedGameParser.SavedGameState gameState ) {
+		for (JTextField valueField : stringMap.values())
+			valueField.setText("");
+
+		for (JCheckBox valueCheck : boolMap.values())
+			valueCheck.setSelected(false);
+
+		for (JSlider valueSlider : sliderMap.values())
+			valueSlider.setValue(0);
+
+		for (JLabel valueReminder : reminderMap.values())
+			valueReminder.setText("");
+
+		if ( gameState != null ) {
+			SavedGameParser.ShipState shipState = gameState.getPlayerShipState();
+			ShipBlueprint shipBlueprint = DataManager.get().getShip( shipState.getShipBlueprintId() );
+			if ( shipBlueprint == null )
+				throw new RuntimeException( String.format("Could not find blueprint for%s ship: %s", (shipState.isAuto() ? " auto" : ""), shipState.getShipName()) );
+
+			setStringAndReminder( SHIP_NAME, gameState.getPlayerShipName() );
+
+			sliderMap.get(HULL).setMaximum( shipBlueprint.getHealth().amount );
+			setSliderAndReminder( HULL, shipState.getHullAmt() );
+
+			setStringAndReminder( FUEL, ""+shipState.getFuelAmt() );
+			setStringAndReminder( DRONE_PARTS, ""+shipState.getDronePartsAmt() );
+			setStringAndReminder( MISSILES, ""+shipState.getMissilesAmt() );
+			setStringAndReminder( SCRAP, ""+shipState.getScrapAmt() );
+			setBoolAndReminder( HAZARDS_VISIBLE, gameState.areSectorHazardsVisible() );
+
+			int meanOxygen = 0;
+			int breachCount = shipState.getBreachMap().size();
+			int fireCount = 0;
+			for (SavedGameParser.RoomState room : shipState.getRoomList()) {
+				meanOxygen += room.getOxygen();
+
+				for (int[] square : room.getSquareList()) {
+					if ( square[0] > 0 ) fireCount++;
+				}
+			}
+			meanOxygen /= shipState.getRoomList().size();
+
+			setBoolAndReminder( FULL_OXYGEN, (meanOxygen == 100), meanOxygen +"%" );
+			setBoolAndReminder( NO_BREACHES, (breachCount == 0), ""+breachCount );
+			setBoolAndReminder( NO_FIRES, (fireCount == 0), ""+fireCount );
+		}
+
+		this.repaint();
+	}
+
+	public void updateGameState( SavedGameParser.SavedGameState gameState ) {
+		SavedGameParser.ShipState shipState = gameState.getPlayerShipState();
+		String newString = null;
+
+		newString = stringMap.get(SHIP_NAME).getText();
+		if ( newString.length() > 0 ) {
+			gameState.setPlayerShipName( newString );
+			shipState.setShipName( newString );
+		}
+
+		shipState.setHullAmt( sliderMap.get(HULL).getValue() );
+
+		newString = stringMap.get(FUEL).getText();
+		try { shipState.setFuelAmt(Integer.parseInt(newString)); }
+		catch (NumberFormatException e) {}
+
+		newString = stringMap.get(DRONE_PARTS).getText();
+		try { shipState.setDronePartsAmt(Integer.parseInt(newString)); }
+		catch (NumberFormatException e) {}
+
+		newString = stringMap.get(MISSILES).getText();
+		try { shipState.setMissilesAmt(Integer.parseInt(newString)); }
+		catch (NumberFormatException e) {}
+
+		newString = stringMap.get(SCRAP).getText();
+		try { shipState.setScrapAmt(Integer.parseInt(newString)); }
+		catch (NumberFormatException e) {}
+
+		gameState.setSectorHazardsVisible( boolMap.get(HAZARDS_VISIBLE).isSelected() );
+
+		boolean fullOxygen = boolMap.get(FULL_OXYGEN).isSelected();
+		boolean noBreaches = boolMap.get(NO_BREACHES).isSelected();
+		boolean noFires = boolMap.get(NO_FIRES).isSelected();
+
+		if ( noBreaches ) shipState.getBreachMap().clear();
+
+		for (SavedGameParser.RoomState room : shipState.getRoomList()) {
+			if ( fullOxygen ) room.setOxygen(100);
+
+			if ( noFires ) {
+				for (int[] square : room.getSquareList()) {
+					square[0] = 0;
+					square[1] = 0;
+					// TODO: Determine if the square's third value is relevant.
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
@@ -25,10 +25,11 @@ public class ShipBlueprint {
 	private String name, desc;
 	
 	private SystemList systemList;
+	private Health health;
 	
 	private int weaponSlots, droneSlots;
 	
-	private Object weaponList, health, maxPower, crewCount; // TODO model
+	private Object weaponList, maxPower, crewCount; // TODO model
 	
 	@XmlRootElement
 	@XmlAccessorType(XmlAccessType.FIELD)
@@ -239,6 +240,13 @@ public class ShipBlueprint {
 		}
 	}
 
+	@XmlRootElement
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class Health {
+		@XmlAttribute
+		public int amount;
+	}
+
 	public String getId() {
 		return id;
 	}
@@ -319,11 +327,11 @@ public class ShipBlueprint {
 		this.weaponList = weaponList;
 	}
 
-	public Object getHealth() {
+	public Health getHealth() {
 		return health;
 	}
 
-	public void setHealth(Object health) {
+	public void setHealth(Health health) {
 		this.health = health;
 	}
 

--- a/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
@@ -35,6 +35,19 @@ public class ShipBlueprint {
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class SystemList {
 
+		public static final String NAME_PILOT = "Pilot";
+		public static final String NAME_DOORS = "Doors";
+		public static final String NAME_SENSORS = "Sensors";
+		public static final String NAME_MEDBAY = "Medbay";
+		public static final String NAME_OXYGEN = "Oxygen";
+		public static final String NAME_SHIELDS = "Shields";
+		public static final String NAME_ENGINES = "Engines";
+		public static final String NAME_WEAPONS = "Weapons";
+		public static final String NAME_DRONE_CTRL = "Drone Ctrl";
+		public static final String NAME_TELEPORTER = "Teleporter";
+		public static final String NAME_CLOAKING = "Cloaking";
+		public static final String NAME_ARTILLERY = "Artillery";
+
 		@XmlRootElement
 		@XmlAccessorType(XmlAccessType.FIELD)
 		public static class RoomSlot {
@@ -220,22 +233,54 @@ public class ShipBlueprint {
 		 * Returns the system's name in a given room, or null.
 		 */
 		public String getSystemNameByRoomId( int roomId ) {
-			if ( getPilotRoom() != null && getPilotRoom().getRoomId() == roomId ) return "Pilot";
-			if ( getDoorsRoom() != null && getDoorsRoom().getRoomId() == roomId ) return "Doors";
-			if ( getSensorsRoom() != null && getSensorsRoom().getRoomId() == roomId ) return "Sensors";
-			if ( getMedicalRoom() != null && getMedicalRoom().getRoomId() == roomId ) return "Medbay";
-			if ( getLifeSupportRoom() != null && getLifeSupportRoom().getRoomId() == roomId ) return "Oxygen";
-			if ( getShieldRoom() != null && getShieldRoom().getRoomId() == roomId ) return "Shields";
-			if ( getEngineRoom() != null && getEngineRoom().getRoomId() == roomId ) return "Engines";
-			if ( getWeaponRoom() != null && getWeaponRoom().getRoomId() == roomId ) return "Weapons";
-			if ( getDroneRoom() != null && getDroneRoom().getRoomId() == roomId ) return "Drone Ctrl";
-			if ( getTeleporterRoom() != null && getTeleporterRoom().getRoomId() == roomId ) return "Teleporter";
-			if ( getCloakRoom() != null && getCloakRoom().getRoomId() == roomId ) return "Cloaking";
+			if ( getPilotRoom() != null && getPilotRoom().getRoomId() == roomId ) return NAME_PILOT;
+			if ( getDoorsRoom() != null && getDoorsRoom().getRoomId() == roomId ) return NAME_DOORS;
+			if ( getSensorsRoom() != null && getSensorsRoom().getRoomId() == roomId ) return NAME_SENSORS;
+			if ( getMedicalRoom() != null && getMedicalRoom().getRoomId() == roomId ) return NAME_MEDBAY;
+			if ( getLifeSupportRoom() != null && getLifeSupportRoom().getRoomId() == roomId ) return NAME_OXYGEN;
+			if ( getShieldRoom() != null && getShieldRoom().getRoomId() == roomId ) return NAME_SHIELDS;
+			if ( getEngineRoom() != null && getEngineRoom().getRoomId() == roomId ) return NAME_ENGINES;
+			if ( getWeaponRoom() != null && getWeaponRoom().getRoomId() == roomId ) return NAME_WEAPONS;
+			if ( getDroneRoom() != null && getDroneRoom().getRoomId() == roomId ) return NAME_DRONE_CTRL;
+			if ( getTeleporterRoom() != null && getTeleporterRoom().getRoomId() == roomId ) return NAME_TELEPORTER;
+			if ( getCloakRoom() != null && getCloakRoom().getRoomId() == roomId ) return NAME_CLOAKING;
 			if ( getArtilleryRooms() != null ) {
 				for ( SystemRoom artilleryRoom : artilleryRooms ) {
-					if ( artilleryRoom.getRoomId() == roomId ) return "Artillery";
+					if ( artilleryRoom.getRoomId() == roomId ) return NAME_ARTILLERY;
 				}
 			}
+			return null;
+		}
+
+		/**
+		 * Returns a system's roomId(s), or null.
+		 */
+		public int[] getRoomIdBySystemName( String name ) {
+			SystemList.SystemRoom systemRoom = null;
+			if ( name.equals(NAME_PILOT) ) systemRoom = getPilotRoom();
+			else if ( name.equals(NAME_DOORS) ) systemRoom = getDoorsRoom();
+			else if ( name.equals(NAME_SENSORS) ) systemRoom = getSensorsRoom();
+			else if ( name.equals(NAME_MEDBAY) ) systemRoom = getMedicalRoom();
+			else if ( name.equals(NAME_OXYGEN) ) systemRoom = getLifeSupportRoom();
+			else if ( name.equals(NAME_SHIELDS) ) systemRoom = getShieldRoom();
+			else if ( name.equals(NAME_ENGINES) ) systemRoom = getEngineRoom();
+			else if ( name.equals(NAME_WEAPONS) ) systemRoom = getWeaponRoom();
+			else if ( name.equals(NAME_DRONE_CTRL) ) systemRoom = getDroneRoom();
+			else if ( name.equals(NAME_TELEPORTER) ) systemRoom = getTeleporterRoom();
+			else if ( name.equals(NAME_CLOAKING) ) systemRoom = getCloakRoom();
+			if ( systemRoom != null ) return new int[] { systemRoom.getRoomId() };
+
+			if ( name.equals(NAME_ARTILLERY) ) {
+				if ( getArtilleryRooms() != null && getArtilleryRooms().size() > 0 ) {
+					int n = 0;
+					int[] result = new int[getArtilleryRooms().size()];
+					for ( SystemRoom artilleryRoom : artilleryRooms ) {
+						result[n++] = artilleryRoom.getRoomId();
+					}
+					return result;
+				}
+			}
+
 			return null;
 		}
 	}

--- a/src/main/java/net/blerf/ftl/xml/ShipChassis.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipChassis.java
@@ -1,0 +1,74 @@
+package net.blerf.ftl.xml;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name="shipChassis")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ShipChassis {
+	@XmlElement(name="img")
+	private ChassisImageBounds imageBounds;
+	private WeaponMountList weaponMountList;
+
+	@XmlRootElement(name="img")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class ChassisImageBounds {
+		@XmlAttribute
+		public int x, y, w, h;
+	}
+
+	@XmlRootElement(name="weaponMounts")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class WeaponMountList {
+		private List<WeaponMount> mount;
+
+		@XmlRootElement(name="mount")
+		@XmlAccessorType(XmlAccessType.FIELD)
+		public static class WeaponMount {
+			public int x, y, gib;
+			public boolean rotate, mirror;
+			public String slide;
+		}
+	}
+
+	@XmlRootElement(name="explosion")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class Explosion {
+		private List<Gib> gib;
+
+		@XmlRootElement(name="gib")
+		@XmlAccessorType(XmlAccessType.FIELD)
+		public static class Gib {
+			private FloatRange velocity;
+			private FloatRange direction;
+			private FloatRange angular;
+			private int x, y;
+
+			@XmlAccessorType(XmlAccessType.FIELD)
+			public static class FloatRange {
+				private float min, max;
+			}
+		}
+	}
+
+	public void setImageBounds( ChassisImageBounds imageBounds ) {
+		this.imageBounds = imageBounds;
+	}
+
+	public ChassisImageBounds getImageBounds() {
+		return imageBounds;
+	}
+
+	public void setWeaponMountList( WeaponMountList weaponMountList ) {
+		this.weaponMountList = weaponMountList;
+	}
+
+	public WeaponMountList getWeaponMountList() {
+		return weaponMountList;
+	}
+}


### PR DESCRIPTION
SavedGameState
- difficultyEasy
- sectorIsHiddenCrystalWorlds
- sectorTreeSeed
- rebelFleetFudge - a random constant applied to the fleet offset each sector
- unknownHeaderAlpha
- sectorNumber changed to be 0-based.

RebelFlagshipState
- Occupancy changed to int
- Found the missing bytes: nearbyShips were eating them for their non-existent cargo.

DoorState
- walkingThrough

ShipLayout
- DoorCoordinate - (x,y,v) that can be used as a HashMap key. (arrays just check identity instead of equality)

ShipBlueprint
- Health

Parser
- writeBool()

RegexDocument - A new class to add character restrictions to JTextFields

SavedGameGeneralPanel - A GUI tab that edits the following...
- Ship Name
- Hull, Fuel, Drone Parts, Missiles, Scrap
- Sector Hazards Visible

SavedGameFloorplanPanel - A GUI tab that reconstructs the appearance of the player's ship
- Breaches - position
- Crew - position, race, and playerControlled; hovering shows their names
- Doors - open and door system's undamaged level
- Fires - position
- System icons - room placement
- Room oxygen - indicates level with tint, and yellow border at 0%
- All rooms' oxygen, breaches, and fires can be reset.

SavedGameParser
- Fixed readSavedGame() and writeSavedGame(), which misinterpreted the order of door states in files (Nth door in saved game file != Nth door in shiplayout text file). With the FloorplanPanel, this oversight became obvious.
