### PR TITLE
Advanced Ship Editing

### DIFF
--- a/src/main/java/net/blerf/ftl/parser/DataManager.java
+++ b/src/main/java/net/blerf/ftl/parser/DataManager.java
@@ -17,6 +17,7 @@ import net.blerf.ftl.xml.Achievement;
 import net.blerf.ftl.xml.Blueprints;
 import net.blerf.ftl.xml.ShipBlueprint;
 import net.blerf.ftl.xml.ShipChassis;
+import net.blerf.ftl.xml.SystemBlueprint;
 import net.blerf.ftl.xml.WeaponBlueprint;
 
 import org.apache.logging.log4j.LogManager;
@@ -41,6 +42,7 @@ public class DataManager implements Closeable {
 	private Blueprints blueprints;
 	private Blueprints autoBlueprints;
 
+	private Map<String, SystemBlueprint> systems;
 	private Map<String, WeaponBlueprint> weapons;	
 	private Map<String, ShipBlueprint> ships;
 	private Map<String, ShipBlueprint> autoShips;
@@ -81,6 +83,10 @@ public class DataManager implements Closeable {
 			for( Achievement ach : achievements )
 				if ( ach.getShipId() == null )
 					generalAchievements.add(ach);
+
+			systems = new HashMap<String, SystemBlueprint>();
+			for ( SystemBlueprint system : blueprints.getSystemBlueprint() )
+				systems.put( system.getId(), system );
 
 			weapons = new HashMap<String, WeaponBlueprint>();
 			for ( WeaponBlueprint weapon : blueprints.getWeaponBlueprint() )
@@ -169,6 +175,13 @@ public class DataManager implements Closeable {
 		return achievements;
 	}
 	
+	public SystemBlueprint getSystem( String id ) {
+		SystemBlueprint result = systems.get(id);
+		if ( result == null )
+			log.error( "No SystemBlueprint found for id: "+ id );
+		return result;
+	}
+
 	public WeaponBlueprint getWeapon( String id ) {
 		WeaponBlueprint result = weapons.get(id);
 		if ( result == null )

--- a/src/main/java/net/blerf/ftl/parser/DataManager.java
+++ b/src/main/java/net/blerf/ftl/parser/DataManager.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,7 +89,7 @@ public class DataManager implements Closeable {
 			for ( SystemBlueprint system : blueprints.getSystemBlueprint() )
 				systems.put( system.getId(), system );
 
-			weapons = new HashMap<String, WeaponBlueprint>();
+			weapons = new LinkedHashMap<String, WeaponBlueprint>();
 			for ( WeaponBlueprint weapon : blueprints.getWeaponBlueprint() )
 				weapons.put( weapon.getId(), weapon );
 
@@ -174,7 +175,7 @@ public class DataManager implements Closeable {
 	public List<Achievement> getAchievements() {
 		return achievements;
 	}
-	
+
 	public SystemBlueprint getSystem( String id ) {
 		SystemBlueprint result = systems.get(id);
 		if ( result == null )
@@ -187,6 +188,10 @@ public class DataManager implements Closeable {
 		if ( result == null )
 			log.error( "No WeaponBlueprint found for id: "+ id );
 		return result;
+	}
+
+	public Map<String, WeaponBlueprint> getWeapons() {
+		return weapons;
 	}
 
 	public ShipBlueprint getShip( String id ) {

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1721,9 +1721,12 @@ public class SavedGameParser extends DatParser {
 
 
 
-	public class DoorState {
-		private boolean open;
-		private boolean walkingThrough;
+	public static class DoorState {
+		private boolean open = false;
+		private boolean walkingThrough = false;
+
+		public DoorState() {
+		}
 
 		public DoorState( boolean open, boolean walkingThrough ) {
 			this.open = open;

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1439,31 +1439,54 @@ public class SavedGameParser extends DatParser {
 
 
 
-	public class CrewState {
+	public static class CrewState {
 		// TODO: magic numbers.
-		// Make these static when the class gets its own file.
-		public final int MASTERY_INTERVAL_PILOT = 15;
-		public final int MASTERY_INTERVAL_ENGINE = 15;
-		public final int MASTERY_INTERVAL_SHIELD = 55;
-		public final int MASTERY_INTERVAL_WEAPON = 65;
-		public final int MASTERY_INTERVAL_REPAIR = 18;
-		public final int MASTERY_INTERVAL_COMBAT = 8;
+		// Might be worth putting in the config file.
+		public static final int MASTERY_INTERVAL_PILOT = 15;
+		public static final int MASTERY_INTERVAL_ENGINE = 15;
+		public static final int MASTERY_INTERVAL_SHIELD = 55;
+		public static final int MASTERY_INTERVAL_WEAPON = 65;
+		public static final int MASTERY_INTERVAL_REPAIR = 18;
+		public static final int MASTERY_INTERVAL_COMBAT = 8;
+
+		public static final int MAX_HEALTH_CRYSTAL = 120;
+		public static final int MAX_HEALTH_ENGI = 100;
+		public static final int MAX_HEALTH_ENERGY = 70;
+		public static final int MAX_HEALTH_HUMAN = 100;
+		public static final int MAX_HEALTH_MANTIS = 100;
+		public static final int MAX_HEALTH_ROCK = 150;
+		public static final int MAX_HEALTH_SLUG = 100;
+		public static final int MAX_HEALTH_BATTLE = 150;
+		public static final int MAX_HEALTH_REPAIR = 25;  // Might not be a race.
+
+		public static int getMaxHealth( String race ) {
+			if ( race.equals("crystal") ) return MAX_HEALTH_CRYSTAL;
+			else if ( race.equals("engi") ) return MAX_HEALTH_ENGI;
+			else if ( race.equals("energy") ) return MAX_HEALTH_ENERGY;
+			else if ( race.equals("human") ) return MAX_HEALTH_HUMAN;
+			else if ( race.equals("mantis") ) return MAX_HEALTH_MANTIS;
+			else if ( race.equals("rock") ) return MAX_HEALTH_ROCK;
+			else if ( race.equals("slug") ) return MAX_HEALTH_SLUG;
+			else if ( race.equals("battle") ) return MAX_HEALTH_BATTLE;
+			else if ( race.equals("repair") ) return MAX_HEALTH_REPAIR;
+			else throw new RuntimeException( "No max health known for race: "+ race );
+		}
 
 		// Neither Crystal crews' lockdown, nor its cooldown is stored.
 		// Zoltan-produced power is not stored in SystemState.
 
 		private String name, race;
 		private boolean enemyBoardingDrone = false;
-		private int health;
+		private int health=0;
 		private int blueprintRoomId;
 		private int roomSquare;  // 0-based, L-to-R wrapped row.
-		private boolean playerControlled;
-		private int pilotSkill, engineSkill, shieldSkill;
-		private int weaponSkill, repairSkill, combatSkill;
-		private int repairs, combatKills, pilotedEvasions;
-		private int jumpsSurvived, skillMasteries;
+		private boolean playerControlled=false;
+		private int pilotSkill=0, engineSkill=0, shieldSkill=0;
+		private int weaponSkill=0, repairSkill=0, combatSkill=0;
+		private int repairs=0, combatKills=0, pilotedEvasions=0;
+		private int jumpsSurvived=0, skillMasteries=0;
 		private int x, y;
-		private int gender;  // 1=Male, 0=Female.
+		private int gender=1;  // 1=Male, 0=Female.
 
 		public CrewState() {
 		}
@@ -1516,6 +1539,10 @@ public class SavedGameParser extends DatParser {
 		 * name will change to "Anti-Personnel Drone", race
 		 * will be "battle", and playerControlled will be
 		 * false.
+		 *
+		 * If after loading in-game, you re-edit this to false
+		 * and leave the "battle" race, the game will change
+		 * it to "human".
 		 *
 		 * Presumably this is so intruders can persist without
 		 * a ship, which would normally have a drones section

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -547,13 +547,13 @@ public class SavedGameParser extends DatParser {
 			system.setDamagedBars( readInt(in) );
 			system.setIonizedBars( readInt(in) );
 
-			int miscTicks = readInt(in);
-			if ( miscTicks == -2147483648 )
-				miscTicks = Integer.MIN_VALUE;
-			system.setMiscTicks( miscTicks );
+			int deionizationTicks = readInt(in);
+			if ( deionizationTicks == -2147483648 )
+				deionizationTicks = Integer.MIN_VALUE;
+			system.setDeionizationTicks( deionizationTicks );
 
 			system.setRepairProgress( readInt(in) );
-			system.setBurnProgress( readInt(in) );
+			system.setDamageProgress( readInt(in) );
 		}
 		return system;
 	}
@@ -565,13 +565,13 @@ public class SavedGameParser extends DatParser {
 			writeInt( out, system.getDamagedBars() );
 			writeInt( out, system.getIonizedBars() );
 
-			if ( system.getMiscTicks() == Integer.MIN_VALUE )
+			if ( system.getDeionizationTicks() == Integer.MIN_VALUE )
 				writeInt( out, -2147483648 );
 			else
-				writeInt( out, system.getMiscTicks() );
+				writeInt( out, system.getDeionizationTicks() );
 
 			writeInt( out, system.getRepairProgress() );
-			writeInt( out, system.getBurnProgress() );
+			writeInt( out, system.getDamageProgress() );
 		}
 	}
 
@@ -1163,6 +1163,8 @@ public class SavedGameParser extends DatParser {
 
 
 	public class ShipState {
+		public static final int MAX_RESERVE_POWER = 25;  // TODO: Magic number.
+
 		private boolean auto = false;  // Is autoShip.
 		private String shipName, shipBlueprintId, shipLayoutId;
 		private String shipGfxBaseName;
@@ -1636,27 +1638,27 @@ public class SavedGameParser extends DatParser {
 
 
 
-	public class SystemState {
+	public static class SystemState {
 		private String systemId;
 		private int capacity = 0;
 		private int power = 0;
 		private int damagedBars = 0;      // Number of unusable power bars.
 		private int ionizedBars = 0;      // Number of disabled power bars; -1 while cloaked.
 		private int repairProgress = 0;   // Turns bar yellow.
-		private int burnProgress = 0;     // Turns bar red.
-		private int miscTicks = Integer.MIN_VALUE;  // Millisecond counter.
+		private int damageProgress = 0;   // Turns bar red.
+		private int deionizationTicks = Integer.MIN_VALUE;  // Millisecond counter.
 
 		// ionizedBars may briefly be -1 initially when a system
 		// disables itself. Then ionizedBars will be set to capacity+1.
 
-		// miscTicks is reset upon loading.
-		// Whatever needs timing will respond to it as it increments,
-		// including resetting after intervals. If nothing needs it,
-		// it may be 0, or more often, MIN_INT (signed 32bit \x0000_0080)
-		// of the compiler that built FTL. This parser will translate that
+		// deionizationTicks is reset upon loading.
+		// The game's interface responds as it increments, including
+		// resetting after intervals. If not needed, it may be 0, or
+		// more often, MIN_INT (signed 32bit \x0000_0080) of the
+		// compiler that built FTL. This parser will translate that
 		// to Java's equivalent minimum during reading, and back during
 		// writing.
-		//   Deionization: each bar counts to 5000.
+		//   Deionization of each bar counts to 5000.
 		//
 		// TODO:
 		// Nearly every system has been observed with non-zero values,
@@ -1675,28 +1677,28 @@ public class SavedGameParser extends DatParser {
 		public void setDamagedBars( int n ) { damagedBars = n; }
 		public void setIonizedBars( int n ) { ionizedBars = n; }
 		public void setRepairProgress( int n ) { repairProgress = n; }
-		public void setBurnProgress( int n ) { burnProgress = n; }
-		public void setMiscTicks( int n ) { miscTicks = n; }
+		public void setDamageProgress( int n ) { damageProgress = n; }
+		public void setDeionizationTicks( int n ) { deionizationTicks = n; }
 
 		public int getCapacity() { return capacity; }
 		public int getPower() { return power; }
 		public int getDamagedBars() { return damagedBars; }
 		public int getIonizedBars() { return ionizedBars; }
 		public int getRepairProgress() { return repairProgress; }
-		public int getBurnProgress() { return burnProgress; }
-		public int getMiscTicks() { return miscTicks; }
+		public int getDamageProgress() { return damageProgress; }
+		public int getDeionizationTicks() { return deionizationTicks; }
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
 			if (capacity > 0) {
-				result.append(String.format("SystemId:        %s\n", systemId));
-				result.append(String.format("Power:           %d/%d\n", power, capacity));
-				result.append(String.format("Damaged Bars:    %3d\n", damagedBars));
-				result.append(String.format("Ionized Bars:    %3d\n", ionizedBars));
-				result.append(String.format("Repair Progress: %3d%%\n", repairProgress));
-				result.append(String.format("Burn Progress:   %3d%%\n", burnProgress));
-				result.append(String.format("Misc Ticks:      %s\n", (miscTicks==Integer.MIN_VALUE ? "N/A" : miscTicks) ));
+				result.append(String.format("SystemId:           %s\n", systemId));
+				result.append(String.format("Power:              %d/%d\n", power, capacity));
+				result.append(String.format("Damaged Bars:       %3d\n", damagedBars));
+				result.append(String.format("Ionized Bars:       %3d\n", ionizedBars));
+				result.append(String.format("Repair Progress:    %3d%%\n", repairProgress));
+				result.append(String.format("Damage Progress:    %3d%%\n", damageProgress));
+				result.append(String.format("Deionization Ticks: %s\n", (deionizationTicks==Integer.MIN_VALUE ? "N/A" : deionizationTicks) ));
 			} else {
 				result.append(String.format("%s: N/A\n", systemId));
 			}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1475,7 +1475,7 @@ public class SavedGameParser extends DatParser {
 		// Neither Crystal crews' lockdown, nor its cooldown is stored.
 		// Zoltan-produced power is not stored in SystemState.
 
-		private String name, race;
+		private String name="Frank", race="human";
 		private boolean enemyBoardingDrone = false;
 		private int health=0;
 		private int blueprintRoomId;

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1639,6 +1639,10 @@ public class SavedGameParser extends DatParser {
 
 
 	public static class SystemState {
+		// Above this number, FTL can't find a number image to use.
+		// A warning pic will appear in its place.
+		public static final int MAX_IONIZED_BARS = 9;  // TODO: Magic number.
+
 		private String systemId;
 		private int capacity = 0;
 		private int power = 0;

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -478,7 +478,7 @@ public class SavedGameParser extends DatParser {
 		crew.setWeaponSkill( readInt(in) );
 		crew.setRepairSkill( readInt(in) );
 		crew.setCombatSkill( readInt(in) );
-		crew.setGender( readInt(in) );
+		crew.setMale( readBool(in) );
 		crew.setRepairs( readInt(in) );
 		crew.setCombatKills( readInt(in) );
 		crew.setPilotedEvasions( readInt(in) );
@@ -503,7 +503,7 @@ public class SavedGameParser extends DatParser {
 		writeInt( out, crew.getWeaponSkill() );
 		writeInt( out, crew.getRepairSkill() );
 		writeInt( out, crew.getCombatSkill() );
-		writeInt( out, crew.getGender() );
+		writeBool( out, crew.isMale() );
 		writeInt( out, crew.getRepairs() );
 		writeInt( out, crew.getCombatKills() );
 		writeInt( out, crew.getPilotedEvasions() );
@@ -1486,7 +1486,7 @@ public class SavedGameParser extends DatParser {
 		private int repairs=0, combatKills=0, pilotedEvasions=0;
 		private int jumpsSurvived=0, skillMasteries=0;
 		private int x, y;
-		private int gender=1;  // 1=Male, 0=Female.
+		private boolean male=true;
 
 		public CrewState() {
 		}
@@ -1505,7 +1505,6 @@ public class SavedGameParser extends DatParser {
 		public void setWeaponSkill( int n ) {weaponSkill = n; }
 		public void setRepairSkill( int n ) {repairSkill = n; }
 		public void setCombatSkill( int n ) {combatSkill = n; }
-		public void setGender( int gender ) { this.gender = gender; }
 		public void setRepairs( int n ) { repairs = n; }
 		public void setCombatKills( int n ) { combatKills = n; }
 		public void setPilotedEvasions( int n ) { pilotedEvasions = n; }
@@ -1526,12 +1525,25 @@ public class SavedGameParser extends DatParser {
 		public int getWeaponSkill() { return weaponSkill; }
 		public int getRepairSkill() { return repairSkill; }
 		public int getCombatSkill() { return combatSkill; }
-		public int getGender() { return gender; }
 		public int getRepairs() { return repairs; }
 		public int getCombatKills() { return combatKills; }
 		public int getPilotedEvasions() { return pilotedEvasions; }
 		public int getJumpsSurvived() { return jumpsSurvived; }
 		public int getSkillMasteries() { return skillMasteries; }
+
+		/**
+		 * Toggles gender.
+		 * Humans with this set to false have a
+		 * female image. Other races accept the
+		 * flag but ignore it.
+		 *
+		 * No Andorians in the game, so this is
+		 * only a two-state boolean.
+		 */
+		public void setMale( boolean b ) {
+			male = b;
+		}
+		public boolean isMale() { return male; }
 
 		/**
 		 * Sets whether this crew member is a hostile drone.
@@ -1562,7 +1574,7 @@ public class SavedGameParser extends DatParser {
 			result.append(String.format("Name:              %s\n", name));
 			result.append(String.format("Race:              %s\n", race));
 			result.append(String.format("Enemy Drone:       %b\n", enemyBoardingDrone));
-			result.append(String.format("Gender:            %s\n", (gender == 1 ? "Male" : "Female") ));
+			result.append(String.format("Gender:            %s\n", (male ? "Male" : "Female") ));
 			result.append(String.format("Health:            %3d\n", health));
 			result.append(String.format("RoomId:            %3d\n", blueprintRoomId));
 			result.append(String.format("Room Square:       %3d\n", roomSquare));

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -594,10 +594,10 @@ public class SavedGameParser extends DatParser {
 	public void writeRoom( OutputStream out, RoomState room ) throws IOException {
 		writeInt( out, room.getOxygen() );
 
-		for (int[] square : room.getSquareList()) {
-			writeInt( out, square[0] );
-			writeInt( out, square[1] );
-			writeInt( out, square[2] );
+		for (SquareState square : room.getSquareList()) {
+			writeInt( out, square.fireHealth );
+			writeInt( out, square.ignitionProgress );
+			writeInt( out, square.gamma );
 		}
 	}
 
@@ -1712,9 +1712,9 @@ public class SavedGameParser extends DatParser {
 
 
 
-	public class RoomState {
+	public static class RoomState {
 		private int oxygen = 100;
-		private ArrayList<int[]> squareList = new ArrayList<int[]>();
+		private ArrayList<SquareState> squareList = new ArrayList<SquareState>();
 
 		public void setOxygen( int n ) { oxygen = n; }
 		public int getOxygen() { return oxygen; }
@@ -1732,22 +1732,36 @@ public class SavedGameParser extends DatParser {
 		 * @param gamma -1?
 		 */
 		public void addSquare( int fireHealth, int ignitionProgress, int gamma ) {
-			squareList.add( new int[] {fireHealth, ignitionProgress, gamma} );
+			squareList.add( new SquareState( fireHealth, ignitionProgress, gamma ) );
 		}
-		public int[] getSquare( int n ) {
+		public SquareState getSquare( int n ) {
 			return squareList.get(n);
 		}
 
-		public ArrayList<int[]> getSquareList() { return squareList; }
+		public ArrayList<SquareState> getSquareList() { return squareList; }
 
 		@Override
 		public String toString() {
 			StringBuilder result = new StringBuilder();
 			result.append(String.format("Oxygen: %3d%%\n", oxygen));
-			for (int[] square : squareList) {
-				result.append(String.format("Square: Fire HP: %3d, Ignition: %3d%% %2d?\n", square[0], square[1], square[2]));
+			for (SquareState square : squareList) {
+				result.append(String.format("Square: Fire HP: %3d, Ignition: %3d%%, Gamma?: %2d\n", square.fireHealth, square.ignitionProgress, square.gamma));
 			}
 			return result.toString();
+		}
+	}
+
+	public static class SquareState {
+		public int fireHealth = 0;
+		public int ignitionProgress = 0;
+		public int gamma = -1;
+
+		public SquareState( int fireHealth, int ignitionProgress, int gamma ) {
+			this.fireHealth = fireHealth;
+			this.ignitionProgress = ignitionProgress;
+			this.gamma = gamma;
+		}
+		public SquareState() {
 		}
 	}
 

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -467,8 +467,8 @@ public class SavedGameParser extends DatParser {
 		crew.setRace( readString(in) );
 		crew.setEnemyBoardingDrone( readBool(in) );
 		crew.setHealth( readInt(in) );
-		crew.setX( readInt(in) );
-		crew.setY( readInt(in) );
+		crew.setSpriteX( readInt(in) );
+		crew.setSpriteY( readInt(in) );
 		crew.setRoomId( readInt(in) );
 		crew.setRoomSquare( readInt(in) );
 		crew.setPlayerControlled( readBool(in) );
@@ -492,8 +492,8 @@ public class SavedGameParser extends DatParser {
 		writeString( out, crew.getRace() );
 		writeBool( out, crew.isEnemyBoardingDrone() );
 		writeInt( out, crew.getHealth() );
-		writeInt( out, crew.getX() );
-		writeInt( out, crew.getY() );
+		writeInt( out, crew.getSpriteX() );
+		writeInt( out, crew.getSpriteY() );
 		writeInt( out, crew.getRoomId() );
 		writeInt( out, crew.getRoomSquare() );
 		writeBool( out, crew.isPlayerControlled() );
@@ -595,8 +595,8 @@ public class SavedGameParser extends DatParser {
 		DroneState drone = new DroneState( readString(in) );
 		drone.setArmed( readBool(in) );
 		drone.setPlayerControlled( readBool(in) );
-		drone.setX( readInt(in) );
-		drone.setY( readInt(in) );
+		drone.setSpriteX( readInt(in) );
+		drone.setSpriteY( readInt(in) );
 		drone.setRoomId( readInt(in) );
 		drone.setRoomSquare( readInt(in) );
 		drone.setHealth( readInt(in) );
@@ -607,8 +607,8 @@ public class SavedGameParser extends DatParser {
 		writeString( out, drone.getDroneId() );
 		writeBool( out, drone.isArmed() );
 		writeBool( out, drone.isPlayerControlled() );
-		writeInt( out, drone.getX() );
-		writeInt( out, drone.getY() );
+		writeInt( out, drone.getSpriteX() );
+		writeInt( out, drone.getSpriteY() );
 		writeInt( out, drone.getRoomId() );
 		writeInt( out, drone.getRoomSquare() );
 		writeInt( out, drone.getHealth() );
@@ -1485,7 +1485,7 @@ public class SavedGameParser extends DatParser {
 		private int weaponSkill=0, repairSkill=0, combatSkill=0;
 		private int repairs=0, combatKills=0, pilotedEvasions=0;
 		private int jumpsSurvived=0, skillMasteries=0;
-		private int x, y;
+		private int spriteX, spriteY;
 		private boolean male=true;
 
 		public CrewState() {
@@ -1494,8 +1494,6 @@ public class SavedGameParser extends DatParser {
 		public void setName( String s ) {name = s; }
 		public void setRace( String s ) {race = s; }
 		public void setHealth( int n ) {health = n; }
-		public void setX( int x ) { this.x = x; };
-		public void setY( int y ) { this.y = y; };
 		public void setRoomId( int n ) {blueprintRoomId = n; }
 		public void setRoomSquare( int n ) { roomSquare = n; }
 		public void setPlayerControlled( boolean b ) { playerControlled = b; }
@@ -1514,8 +1512,6 @@ public class SavedGameParser extends DatParser {
 		public String getName() { return name; }
 		public String getRace() { return race; }
 		public int getHealth() { return health; }
-		public int getX() { return x; }
-		public int getY() { return y; }
 		public int getRoomId() { return blueprintRoomId; }
 		public int getRoomSquare() { return roomSquare; }
 		public boolean isPlayerControlled() { return playerControlled; }
@@ -1530,6 +1526,24 @@ public class SavedGameParser extends DatParser {
 		public int getPilotedEvasions() { return pilotedEvasions; }
 		public int getJumpsSurvived() { return jumpsSurvived; }
 		public int getSkillMasteries() { return skillMasteries; }
+
+		/**
+		 * Sets the position of the crew's image.
+		 *
+		 * Technically the roomId/square fields set the
+		 * crew's desired location. This field is where
+		 * the crew realy is, possibly en route.
+		 *
+		 * It's the position of the crew image's center,
+		 * relative to the top-left square's corner, in
+		 * pixels, plus (the ShipLayout's offset times
+		 * the square-size, which is 35).
+		 */
+		public void setSpriteX( int n ) { spriteX = n; };
+		public void setSpriteY( int n ) { spriteY = n; };
+		public int getSpriteX() { return spriteX; }
+		public int getSpriteY() { return spriteY; }
+
 
 		/**
 		 * Toggles gender.
@@ -1579,7 +1593,7 @@ public class SavedGameParser extends DatParser {
 			result.append(String.format("RoomId:            %3d\n", blueprintRoomId));
 			result.append(String.format("Room Square:       %3d\n", roomSquare));
 			result.append(String.format("Player Controlled: %b\n", playerControlled));
-			result.append(String.format("Position:          %3d,%3d\n", x, y));
+			result.append(String.format("Sprite Position:   %3d,%3d\n", spriteX, spriteY));
 			result.append(String.format("Pilot Skill:       %3d (Mastery Interval: %2d)\n", pilotSkill, MASTERY_INTERVAL_PILOT));
 			result.append(String.format("Engine Skill:      %3d (Mastery Interval: %2d)\n", engineSkill, MASTERY_INTERVAL_ENGINE));
 			result.append(String.format("Shield Skill:      %3d (Mastery Interval: %2d)\n", shieldSkill, MASTERY_INTERVAL_SHIELD));
@@ -1774,9 +1788,9 @@ public class SavedGameParser extends DatParser {
 		private String droneId;
 		private boolean armed = false;
 		private boolean playerControlled = true;  // False when not armed.
-		private int x = -1, y = -1;        // -1 when not armed.
-		private int blueprintRoomId = -1;  // -1 when not armed.
-		private int roomSquare = -1;       // -1 when not armed.
+		private int spriteX = -1, spriteY = -1;   // -1 when body not present.
+		private int blueprintRoomId = -1;  // -1 when body not present.
+		private int roomSquare = -1;       // -1 when body not present.
 		private int health = 1;
 
 
@@ -1788,16 +1802,16 @@ public class SavedGameParser extends DatParser {
 
 		public void setArmed( boolean b ) { armed = b; }
 		public void setPlayerControlled( boolean b ) { playerControlled = b; }
-		public void setX( int n ) { x = n; }
-		public void setY( int n ) { y = n; }
+		public void setSpriteX( int n ) { spriteX = n; }
+		public void setSpriteY( int n ) { spriteY = n; }
 		public void setRoomId( int n ) { blueprintRoomId = n; }
 		public void setRoomSquare( int n ) { roomSquare = n; }
 		public void setHealth( int n ) { health = n; }
 
 		public boolean isArmed() { return armed; }
 		public boolean isPlayerControlled() { return playerControlled; }
-		public int getX() { return x; }
-		public int getY() { return y; }
+		public int getSpriteX() { return spriteX; }
+		public int getSpriteY() { return spriteY; }
 		public int getRoomId() { return blueprintRoomId; }
 		public int getRoomSquare() { return roomSquare; }
 		public int getHealth() { return health; }
@@ -1811,7 +1825,7 @@ public class SavedGameParser extends DatParser {
 			result.append(String.format("RoomId:            %3d\n", blueprintRoomId));
 			result.append(String.format("Room Square:       %3d\n", roomSquare));
 			result.append(String.format("Player Controlled: %b\n", playerControlled));
-			result.append(String.format("Position:          %3d,%3d\n", x, y));
+			result.append(String.format("Sprite Position:   %3d,%3d\n", spriteX, spriteY));
 			return result.toString();
 		}
 	}

--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -1795,10 +1795,13 @@ public class SavedGameParser extends DatParser {
 
 
 
-	public class WeaponState {
-		private String weaponId;
-		private boolean armed;
-		private int cooldownTicks;  // Increments from 0 until the weapon's cooldown. 0 when not armed.
+	public static class WeaponState {
+		private String weaponId = null;
+		private boolean armed = false;
+		private int cooldownTicks = 0;
+
+		public WeaponState() {
+		}
 
 		public WeaponState( String weaponId, boolean armed, int cooldownTicks ) {
 			this.weaponId = weaponId;
@@ -1806,6 +1809,7 @@ public class SavedGameParser extends DatParser {
 			this.cooldownTicks = cooldownTicks;
 		}
 
+		public void setWeaponId( String s ) { weaponId = s; }
 		public String getWeaponId() { return weaponId; }
 
 		public void setArmed( boolean b ) {
@@ -1814,6 +1818,11 @@ public class SavedGameParser extends DatParser {
 		}
 		public boolean isArmed() { return armed; }
 
+		/**
+		 * Sets the weapon's cooldown ticks.
+		 * This increments from 0 each second until the
+		 * weapon blueprint's cooldown. 0 when not armed.
+		 */
 		public void setCooldownTicks( int n ) { cooldownTicks = n; }
 		public int getCooldownTicks() { return cooldownTicks; }
 

--- a/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
@@ -11,6 +11,7 @@ import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -26,7 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class FieldEditorPanel extends JPanel {
-	public enum ContentType { STRING, INTEGER, BOOLEAN, SLIDER };
+	public enum ContentType { STRING, INTEGER, BOOLEAN, SLIDER, COMBO };
 
 	private static final Logger log = LogManager.getLogger(SavedGameGeneralPanel.class);
 
@@ -34,6 +35,7 @@ public class FieldEditorPanel extends JPanel {
 	private HashMap<String, JTextField> intMap = new HashMap<String, JTextField>();
 	private HashMap<String, JCheckBox> boolMap = new HashMap<String, JCheckBox>();
 	private HashMap<String, JSlider> sliderMap = new HashMap<String, JSlider>();
+	private HashMap<String, JComboBox> comboMap = new HashMap<String, JComboBox>();
 	private HashMap<String, JLabel> reminderMap = new HashMap<String, JLabel>();
 
 	private GridBagConstraints gridC = new GridBagConstraints();
@@ -138,6 +140,13 @@ public class FieldEditorPanel extends JPanel {
 				}
 			});
 		}
+		else if ( contentType == ContentType.COMBO ) {
+			gridC.anchor = GridBagConstraints.CENTER;
+			JComboBox valueCombo = new JComboBox();
+			valueCombo.setEditable(false);
+			comboMap.put( valueName, valueCombo );
+			this.add( valueCombo, gridC );
+		}
 		gridC.gridx++;
 
 		if ( remindersVisible ) {
@@ -193,6 +202,15 @@ public class FieldEditorPanel extends JPanel {
 		if ( remindersVisible ) setReminder( valueName, s );
 	}
 
+	public void setComboAndReminder( String valueName, Object o ) {
+		setSliderAndReminder( valueName, o, o.toString() );
+	}
+	public void setSliderAndReminder( String valueName, Object o, String s ) {
+		JComboBox valueCombo = comboMap.get( valueName );
+		if ( valueCombo != null ) valueCombo.setSelectedItem(o);
+		if ( remindersVisible ) setReminder( valueName, s );
+	}
+
 	public void setReminder( String valueName, String s ) {
 		JLabel valueReminder = reminderMap.get( valueName );
 		if ( valueReminder != null ) valueReminder.setText( "( "+ s +" )" );
@@ -214,6 +232,10 @@ public class FieldEditorPanel extends JPanel {
 		return sliderMap.get( valueName );
 	}
 
+	public JComboBox getCombo( String valueName ) {
+		return comboMap.get( valueName );
+	}
+
 	public void reset() {
 		for (JTextField valueField : stringMap.values())
 			valueField.setText("");
@@ -226,6 +248,9 @@ public class FieldEditorPanel extends JPanel {
 
 		for (JSlider valueSlider : sliderMap.values())
 			valueSlider.setValue(0);
+
+		for (JComboBox valueSlider : comboMap.values())
+			valueSlider.removeAllItems();
 
 		for (JLabel valueReminder : reminderMap.values())
 			valueReminder.setText("");

--- a/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
@@ -90,6 +90,7 @@ public class FieldEditorPanel extends JPanel {
 	public void addRow( String valueName, ContentType contentType ) {
 		gridC.fill = GridBagConstraints.HORIZONTAL;
 		gridC.gridwidth = 1;
+		gridC.weighty = 0.0;
 		gridC.gridx = 0;
 		this.add( new JLabel( valueName +":" ), gridC );
 

--- a/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/FieldEditorPanel.java
@@ -16,6 +16,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
+import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.event.ChangeEvent;
@@ -27,10 +28,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class FieldEditorPanel extends JPanel {
-	public enum ContentType { STRING, INTEGER, BOOLEAN, SLIDER, COMBO };
+	public enum ContentType { WRAPPED_LABEL, LABEL, STRING, INTEGER, BOOLEAN, SLIDER, COMBO };
 
 	private static final Logger log = LogManager.getLogger(SavedGameGeneralPanel.class);
 
+	private HashMap<String, JTextArea> wrappedLabelMap = new HashMap<String, JTextArea>();
+	private HashMap<String, JLabel> labelMap = new HashMap<String, JLabel>();
 	private HashMap<String, JTextField> stringMap = new HashMap<String, JTextField>();
 	private HashMap<String, JTextField> intMap = new HashMap<String, JTextField>();
 	private HashMap<String, JCheckBox> boolMap = new HashMap<String, JCheckBox>();
@@ -97,7 +100,27 @@ public class FieldEditorPanel extends JPanel {
 		this.add( new JLabel( valueName +":" ), gridC );
 
 		gridC.gridx++;
-		if ( contentType == ContentType.STRING ) {
+		if ( contentType == ContentType.WRAPPED_LABEL ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JTextArea valueArea = new JTextArea();
+			valueArea.setBackground(null);
+			valueArea.setEditable( false );
+			valueArea.setBorder(null);
+			valueArea.setLineWrap( true );
+			valueArea.setWrapStyleWord( true );
+			valueArea.setFocusable( false );
+
+			wrappedLabelMap.put( valueName, valueArea );
+			this.add( valueArea, gridC );
+		}
+		else if ( contentType == ContentType.LABEL ) {
+			gridC.anchor = GridBagConstraints.WEST;
+			JLabel valueLbl = new JLabel();
+			valueLbl.setHorizontalAlignment( SwingConstants.CENTER );
+			labelMap.put( valueName, valueLbl );
+			this.add( valueLbl, gridC );
+		}
+		else if ( contentType == ContentType.STRING ) {
 			gridC.anchor = GridBagConstraints.WEST;
 			JTextField valueField = new JTextField();
 			stringMap.put( valueName, valueField );
@@ -216,6 +239,14 @@ public class FieldEditorPanel extends JPanel {
 		if ( valueReminder != null ) valueReminder.setText( "( "+ s +" )" );
 	}
 
+	public JTextArea getWrappedLabel( String valueName ) {
+		return wrappedLabelMap.get( valueName );
+	}
+
+	public JLabel getLabel( String valueName ) {
+		return labelMap.get( valueName );
+	}
+
 	public JTextField getString( String valueName ) {
 		return stringMap.get( valueName );
 	}
@@ -237,6 +268,12 @@ public class FieldEditorPanel extends JPanel {
 	}
 
 	public void reset() {
+		for (JTextArea valueArea : wrappedLabelMap.values())
+			valueArea.setText("");
+
+		for (JLabel valueLbl : labelMap.values())
+			valueLbl.setText("");
+
 		for (JTextField valueField : stringMap.values())
 			valueField.setText("");
 

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -27,6 +27,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionAdapter;
+import java.awt.font.LineMetrics;
 import java.awt.image.BufferedImage;
 import java.awt.image.RasterFormatException;
 import java.awt.image.RescaleOp;
@@ -189,12 +190,22 @@ public class SavedGameFloorplanPanel extends JPanel {
 				}
 			}
 			@Override
+			public void mouseEntered(MouseEvent e) {
+				miscSelector.setDescriptionVisible( true );
+			}
+			@Override
 			public void mouseExited(MouseEvent e) {
+				miscSelector.setDescriptionVisible( false );
 				miscSelector.setMousePoint( -1, -1 );
 			}
 		};
 		miscSelector.addMouseListener( miscListener );
 		miscSelector.addMouseMotionListener( miscListener );
+
+		miscSelector.setCriteria(new SpriteCriteria() {
+			private final String desc = "Select: Door or Weapon";
+			public String getDescription() { return desc; }
+		});
 
 		miscSelector.setCallback(new SpriteSelectionCallback() {
 			public boolean spriteSelected( SpriteSelector spriteSelector, JComponent sprite ) {
@@ -234,7 +245,12 @@ public class SavedGameFloorplanPanel extends JPanel {
 				}
 			}
 			@Override
+			public void mouseEntered(MouseEvent e) {
+				squareSelector.setDescriptionVisible( true );
+			}
+			@Override
 			public void mouseExited(MouseEvent e) {
+				squareSelector.setDescriptionVisible( false );
 				squareSelector.setMousePoint( -1, -1 );
 			}
 		};
@@ -444,6 +460,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 	public void setGameState( SavedGameParser.SavedGameState gameState ) {
 		String prevGfxBaseName = shipGfxBaseName;
+		miscSelector.setVisible( false );
 		miscSelector.setMousePoint( -1, -1 );
 		squareSelector.reset();
 		clearSidePanel();
@@ -778,6 +795,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 		shipPanel.setPreferredSize( new Dimension(floorLbl.getIcon().getIconWidth(), floorLbl.getIcon().getIconHeight()) );
 
+		miscSelector.setVisible( true );
+
 		shipPanel.revalidate();
 		shipPanel.repaint();
 	}
@@ -910,6 +929,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 	private void selectRoom() {
 		squareSelector.reset();
+		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Select: Room";
+			public String getDescription() { return desc; }
+		});
 		squareSelector.setCallback(new SquareSelectionCallback() {
 			public boolean squareSelected( SquareSelector squareSelector, int roomId, int squareId ) {
 				RoomSprite roomSprite = roomSprites.get( roomId );
@@ -923,6 +946,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void selectSystem() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Select: System";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				RoomSprite roomSprite = roomSprites.get( roomId );
@@ -955,6 +982,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void selectCrew() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Select: Crew";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				for (CrewSprite crewSprite : crewSprites) {
@@ -982,6 +1013,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void selectBreach() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Select: Breach";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				for (BreachSprite breachSprite : breachSprites) {
@@ -1009,6 +1044,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void selectFire() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Select: Fire";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				for (FireSprite fireSprite : fireSprites) {
@@ -1036,6 +1075,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void addCrew() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Add: Crew";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				if ( blockedRegions.contains( squareSelector.getSquareRectangle() ) ) return false;
@@ -1067,6 +1110,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void addBreach() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Add: Breach";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				if ( blockedRegions.contains( squareSelector.getSquareRectangle() ) ) return false;
@@ -1093,6 +1140,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void addFire() {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Add: Fire";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				if ( blockedRegions.contains( squareSelector.getSquareRectangle() ) ) return false;
@@ -1119,6 +1170,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private void moveCrew( final CrewSprite mobileSprite ) {
 		squareSelector.reset();
 		squareSelector.setCriteria(new SquareCriteria() {
+			private final String desc = "Move: Crew";
+
+			public String getDescription() { return desc; }
+
 			public boolean isSquareValid( SquareSelector squareSelector, int roomId, int squareId ) {
 				if ( roomId < 0 || squareId < 0 ) return false;
 				if ( blockedRegions.contains( squareSelector.getSquareRectangle() ) ) return false;
@@ -2310,9 +2365,9 @@ public class SavedGameFloorplanPanel extends JPanel {
 			int w = this.getWidth(), h = this.getHeight();
 			g2d.drawRect( 0, 0, w-1, h-1 );
 
-			// Technically it should be Ascent + Descent, but these are numbers.
+			LineMetrics lineMetrics = g2d.getFontMetrics().getLineMetrics(slotString, g2d);
 			int slotStringWidth = g2d.getFontMetrics().stringWidth(slotString);
-			int slotStringHeight = (int)g2d.getFontMetrics().getLineMetrics(slotString, g2d).getAscent();
+			int slotStringHeight = (int)lineMetrics.getAscent() + (int)lineMetrics.getDescent();
 			int margin = 6;
 			if ( rotated ) {
 				int slotStringX = (w-1) - slotStringWidth;
@@ -2742,6 +2797,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		private SquareSelectionCallback callback = null;
 		private Point mousePoint = new Point( -1, -1 );
 		private Rectangle currentRect = null;
+		private boolean paintDescription = false;
 
 		public SquareSelector( HashMap<Rectangle, Integer> roomRegions, HashMap<Rectangle, Integer> squareRegions ) {
 			this.roomRegions = roomRegions;
@@ -2819,8 +2875,16 @@ public class SavedGameFloorplanPanel extends JPanel {
 			return callback;
 		}
 
+		public void setDescriptionVisible( boolean b ) {
+			if ( paintDescription != b ) {
+				paintDescription = b;
+				this.repaint();
+			}
+		}
+
 		public void reset() {
 			this.setVisible(false);
+			setDescriptionVisible(false);
 			setCriteria(null);
 			setCallback(null);
 			setMousePoint( -1, -1 );
@@ -2832,6 +2896,18 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 			Graphics2D g2d = (Graphics2D)g;
 			Color prevColor = g2d.getColor();
+
+			if ( paintDescription && squareCriteria != null ) {
+				String desc = squareCriteria.getDescription();
+				if ( desc != null ) {
+					LineMetrics lineMetrics = g2d.getFontMetrics().getLineMetrics(desc, g2d);
+					int descHeight = (int)lineMetrics.getAscent() + (int)lineMetrics.getDescent();
+					int descX = 8;
+					int descY = descHeight + 6;
+					g2d.setColor( Color.BLACK );
+					g2d.drawString( desc, descX, descY );
+				}
+			}
 
 			if ( currentRect != null ) {
 				Color squareColor = squareCriteria.getSquareColor( this, getRoomId(), getSquareId() );
@@ -2852,6 +2928,11 @@ public class SavedGameFloorplanPanel extends JPanel {
 	public class SquareCriteria {
 		private Color validColor = Color.GREEN.darker();
 		private Color invalidColor = Color.RED.darker();
+
+		/** Returns a message describing what will be selected. */
+		public String getDescription() {
+			return null;
+		}
 
 		/** Returns a highlight color when hovering over a square, or null for none. */
 		public Color getSquareColor( SquareSelector squareSelector, int roomId, int squareId ) {
@@ -2892,6 +2973,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		private SpriteSelectionCallback callback = null;
 		private Point mousePoint = new Point( -1, -1 );
 		private JComponent currentSprite = null;
+		private boolean paintDescription = false;
 
 		public SpriteSelector( ArrayList[] spriteLists ) {
 			this.spriteLists = spriteLists;
@@ -2945,8 +3027,16 @@ public class SavedGameFloorplanPanel extends JPanel {
 			return callback;
 		}
 
+		public void setDescriptionVisible( boolean b ) {
+			if ( paintDescription != b ) {
+				paintDescription = b;
+				this.repaint();
+			}
+		}
+
 		public void reset() {
 			this.setVisible(false);
+			setDescriptionVisible(false);
 			setCriteria(null);
 			setCallback(null);
 			setMousePoint( -1, -1 );
@@ -2958,6 +3048,18 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 			Graphics2D g2d = (Graphics2D)g;
 			Color prevColor = g2d.getColor();
+
+			if ( paintDescription && spriteCriteria != null ) {
+				String desc = spriteCriteria.getDescription();
+				if ( desc != null ) {
+					LineMetrics lineMetrics = g2d.getFontMetrics().getLineMetrics(desc, g2d);
+					int descHeight = (int)lineMetrics.getAscent() + (int)lineMetrics.getDescent();
+					int descX = 8;
+					int descY = descHeight + 6;
+					g2d.setColor( Color.BLACK );
+					g2d.drawString( desc, descX, descY );
+				}
+			}
 
 			if ( currentSprite != null ) {
 				Color spriteColor = spriteCriteria.getSpriteColor( this, currentSprite );
@@ -2979,6 +3081,11 @@ public class SavedGameFloorplanPanel extends JPanel {
 	public class SpriteCriteria {
 		private Color validColor = Color.GREEN.darker();
 		private Color invalidColor = Color.RED.darker();
+
+		/** Returns a message describing what will be selected. */
+		public String getDescription() {
+			return null;
+		}
 
 		/** Returns a highlight color when hovering over a sprite, or null for none. */
 		public Color getSpriteColor( SpriteSelector spriteSelector, JComponent sprite ) {

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -261,6 +261,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		gridC.fill = GridBagConstraints.NONE;
 		gridC.weightx = 0.0;
 		gridC.weighty = 0.0;
+		gridC.gridheight = 2;
 		gridC.gridx++;
 		this.add( sidePanel, gridC );
 
@@ -268,6 +269,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		gridC.fill = GridBagConstraints.HORIZONTAL;
 		gridC.weightx = 1.0;
 		gridC.weighty = 0.0;
+		gridC.gridheight = 1;
 		gridC.gridx = 0;
 		gridC.gridy++;
 		this.add( ctrlPanel, gridC );
@@ -534,12 +536,11 @@ public class SavedGameFloorplanPanel extends JPanel {
 		}
 
 		// Crew.
-		// TODO: Make the sprite fully representative of a CrewState,
-		// so the shipState's list can be cleared and repopulated from scratch.
 		ArrayList<SavedGameParser.CrewState> crewList = shipState.getCrewList();
-		for (int i=0; i < crewList.size(); i++) {
-			CrewSprite crewSprite = crewSprites.get(i);
-			SavedGameParser.CrewState crewState = crewList.get(i);
+		crewList.clear();
+		for (CrewSprite crewSprite : crewSprites) {
+			SavedGameParser.CrewState crewState = new SavedGameParser.CrewState();
+
 			crewState.setName( crewSprite.getName() );
 			crewState.setRace( crewSprite.getRace() );
 			crewState.setHealth( crewSprite.getHealth() );
@@ -568,6 +569,13 @@ public class SavedGameFloorplanPanel extends JPanel {
 			crewState.setPlayerControlled( crewSprite.isPlayerControlled() );
 			crewState.setEnemyBoardingDrone( crewSprite.isEnemyBoardingDrone() );
 			crewState.setMale( crewSprite.isMale() );
+
+			crewState.setRoomId( crewSprite.getRoomId() );
+			crewState.setRoomSquare( crewSprite.getSquareId() );
+			crewState.setSpriteX( crewSprite.getX()+crewSprite.getImageWidth()/2 - originX - tileEdge + shipLayout.getOffsetX()*squareSize );
+			crewState.setSpriteY( crewSprite.getY()+crewSprite.getImageHeight()/2 - originY - tileEdge + shipLayout.getOffsetY()*squareSize );
+
+			crewList.add( crewState );
 		}
 	}
 
@@ -1373,6 +1381,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 		private boolean playerControlled;
 		private boolean enemyBoardingDrone;
 		private boolean male;
+		private int spriteX;
+		private int spriteY;
 
 		public CrewSprite( SavedGameParser.CrewState crewState ) {
 			this.crewImage = crewImage;
@@ -1394,6 +1404,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 			playerControlled = crewState.isPlayerControlled();
 			enemyBoardingDrone = crewState.isEnemyBoardingDrone();
 			male = crewState.isMale();
+			spriteX = crewState.getSpriteX();
+			spriteY = crewState.getSpriteY();
 			makeSane();
 			this.setOpaque(false);
 		}
@@ -1416,6 +1428,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 		public void setPlayerControlled( boolean b ) { playerControlled = b; }
 		public void setEnemyBoardingDrone( boolean b ) { enemyBoardingDrone = b; }
 		public void setMale( boolean b ) { male = b; }
+		public void setSpriteX( int n ) { spriteX = n; }
+		public void setSpriteY( int n ) { spriteY = n; }
 
 		public int getRoomId() { return roomId; }
 		public int getSquareId() { return squareId; }
@@ -1435,6 +1449,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 		public boolean isPlayerControlled() { return playerControlled; }
 		public boolean isEnemyBoardingDrone() { return enemyBoardingDrone; }
 		public boolean isMale() { return male; }
+		public int getSpriteX() { return spriteX; }
+		public int getSpriteY() { return spriteY; }
 
 		public int getImageWidth() { return crewImage.getWidth(); }
 		public int getImageHeight() { return crewImage.getHeight(); }

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -383,15 +383,6 @@ public class SavedGameFloorplanPanel extends JPanel {
 		squareSelector.reset();
 		clearSidePanel();
 
-		SavedGameParser.ShipState shipState = gameState.getPlayerShipState();
-		shipBlueprint = DataManager.get().getShip( shipState.getShipBlueprintId() );
-		shipLayout = DataManager.get().getShipLayout( shipState.getShipLayoutId() );
-		shipChassis = DataManager.get().getShipChassis( shipState.getShipLayoutId() );
-		shipGfxBaseName = shipState.getShipGraphicsBaseName();
-		originX = shipChassis.getImageBounds().x * -1;
-		originY = shipChassis.getImageBounds().y * -1;
-		ShipBlueprint.SystemList blueprintSystems = shipBlueprint.getSystemList();
-
 		for (RoomSprite roomSprite : roomSprites)
 			shipPanel.remove( roomSprite );
 		roomSprites.clear();
@@ -415,6 +406,30 @@ public class SavedGameFloorplanPanel extends JPanel {
 		for (CrewSprite crewSprite : crewSprites)
 			shipPanel.remove( crewSprite );
 		crewSprites.clear();
+
+		if ( gameState == null ) {
+			roomRegions.clear();
+			squareRegions.clear();
+			blockedRegions.clear();
+			baseLbl.setIcon(null);
+			floorLbl.setIcon(null);
+
+			for (JComponent roomDecor : roomDecorations)
+				shipPanel.remove( roomDecor );
+			roomDecorations.clear();
+
+			wallLbl.setIcon(null);
+			return;
+		}
+
+		SavedGameParser.ShipState shipState = gameState.getPlayerShipState();
+		shipBlueprint = DataManager.get().getShip( shipState.getShipBlueprintId() );
+		shipLayout = DataManager.get().getShipLayout( shipState.getShipLayoutId() );
+		shipChassis = DataManager.get().getShipChassis( shipState.getShipLayoutId() );
+		shipGfxBaseName = shipState.getShipGraphicsBaseName();
+		originX = shipChassis.getImageBounds().x * -1;
+		originY = shipChassis.getImageBounds().y * -1;
+		ShipBlueprint.SystemList blueprintSystems = shipBlueprint.getSystemList();
 
 		if ( shipGfxBaseName != prevGfxBaseName ) {
 			// Associate graphical regions with roomIds and squares.

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -819,6 +819,31 @@ public class SavedGameFloorplanPanel extends JPanel {
 		squareSelector.setVisible(true);
 	}
 
+	private void moveCrew( final CrewSprite mobileSprite ) {
+		squareSelector.reset();
+		squareSelector.setCriteria(new SquareCriteria() {
+			public boolean isSquareValid( int roomId, int squareId ) {
+				if ( roomId < 0 || squareId < 0 ) return false;
+				for (CrewSprite crewSprite : crewSprites) {
+					if ( crewSprite.getRoomId() == roomId && crewSprite.getSquareId() == squareId ) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+		squareSelector.setCallback(new SquareSelectionCallback() {
+			public boolean squareSelected( SquareSelector squareSelector, int roomId, int squareId ) {
+				Point center = squareSelector.getSquareCenter();
+				placeSprite( center.x, center.y, mobileSprite );
+				mobileSprite.setRoomId( roomId );
+				mobileSprite.setSquareId( squareId );
+				return false;
+			}
+		});
+		squareSelector.setVisible(true);
+	}
+
 	/** Gets a cropped area of an image and caches the result. */
 	private BufferedImage getCroppedImage( String innerPath, int x, int y, int w, int h) {
 		Rectangle keyRect = new Rectangle( x, y, w, h );
@@ -941,7 +966,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		shipPanel.add( crewSprite, CREW_LAYER );
 	}
 
-	/** Relocates a JComponent within its parent's space. */
+	/** Relocates a JComponent within its parent's null layout. */
 	private void placeSprite( int centerX, int centerY, JComponent sprite ) {
 		Dimension spriteSize = sprite.getSize();
 		sprite.setLocation( centerX-spriteSize.width/2, centerY-spriteSize.height/2 );
@@ -1103,11 +1128,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		JLabel titleLbl = new JLabel(title);
 		titleLbl.setAlignmentX( Component.CENTER_ALIGNMENT );
 		sidePanel.add( titleLbl );
-		sidePanel.add( Box.createVerticalStrut(4) );
-		JSeparator titleSep = new JSeparator(JSeparator.HORIZONTAL);
-		titleSep.setMaximumSize( new Dimension(Short.MAX_VALUE, titleSep.getPreferredSize().height) );
-		sidePanel.add( titleSep );
-		sidePanel.add( Box.createVerticalStrut(4) );
+		addSidePanelSeparator(4);
 
 		// Keep the editor from growing and creating gaps around it.
 		editorPanel.setMaximumSize(editorPanel.getPreferredSize());
@@ -1135,6 +1156,17 @@ public class SavedGameFloorplanPanel extends JPanel {
 				applyCallback.run();
 			}
 		});
+	}
+
+	/**
+	 * Adds a separator to the side panel.
+	 */
+	private void addSidePanelSeparator( int spacerSize ) {
+		sidePanel.add( Box.createVerticalStrut( spacerSize ) );
+		JSeparator newSep = new JSeparator(JSeparator.HORIZONTAL);
+		newSep.setMaximumSize( new Dimension(Short.MAX_VALUE, newSep.getPreferredSize().height) );
+		sidePanel.add( newSep );
+		sidePanel.add( Box.createVerticalStrut( spacerSize ) );
 	}
 
 	private void showRoomEditor( final RoomSprite roomSprite ) {
@@ -1181,6 +1213,20 @@ public class SavedGameFloorplanPanel extends JPanel {
 		};
 		createSidePanel( title, editorPanel, applyCallback );
 
+		addSidePanelSeparator(6);
+
+		JButton removeBtn = new JButton("Remove");
+		removeBtn.setAlignmentX( Component.CENTER_ALIGNMENT );
+		sidePanel.add(removeBtn);
+
+		removeBtn.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				clearSidePanel();
+				breachSprites.remove( breachSprite );
+				shipPanel.remove( breachSprite );
+			}
+		});
+
 		showSidePanel();
 	}
 
@@ -1203,6 +1249,20 @@ public class SavedGameFloorplanPanel extends JPanel {
 			}
 		};
 		createSidePanel( title, editorPanel, applyCallback );
+
+		addSidePanelSeparator(6);
+
+		JButton removeBtn = new JButton("Remove");
+		removeBtn.setAlignmentX( Component.CENTER_ALIGNMENT );
+		sidePanel.add(removeBtn);
+
+		removeBtn.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				clearSidePanel();
+				fireSprites.remove( fireSprite );
+				shipPanel.remove( fireSprite );
+			}
+		});
 
 		showSidePanel();
 	}
@@ -1329,6 +1389,32 @@ public class SavedGameFloorplanPanel extends JPanel {
 			}
 		};
 		createSidePanel( title, editorPanel, applyCallback );
+
+		addSidePanelSeparator(6);
+
+		JButton moveBtn = new JButton("Move To...");
+		moveBtn.setAlignmentX( Component.CENTER_ALIGNMENT );
+		sidePanel.add(moveBtn);
+
+		sidePanel.add( Box.createVerticalStrut(6) );
+
+		JButton removeBtn = new JButton("Remove");
+		removeBtn.setAlignmentX( Component.CENTER_ALIGNMENT );
+		sidePanel.add(removeBtn);
+
+		moveBtn.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				moveCrew( crewSprite );
+			}
+		});
+
+		removeBtn.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				clearSidePanel();
+				crewSprites.remove( crewSprite );
+				shipPanel.remove( crewSprite );
+			}
+		});
 
 		showSidePanel();
 	}

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -173,88 +173,144 @@ public class SavedGameFloorplanPanel extends JPanel {
 		squareSelector.addMouseMotionListener( squareListener );
 
 		Insets ctrlInsets = new Insets(3, 4, 3, 4);
-		JPanel ctrlPanel = new JPanel();
-		ctrlPanel.setLayout( new BoxLayout(ctrlPanel, BoxLayout.X_AXIS) );
-		ctrlPanel.add( new JLabel("Select: ") );
-		JButton selectRoomBtn = new JButton("Room");
+
+		JPanel selectPanel = new JPanel();
+		selectPanel.setLayout( new BoxLayout(selectPanel, BoxLayout.X_AXIS) );
+		selectPanel.setBorder( BorderFactory.createTitledBorder("Select") );
+		final JButton selectRoomBtn = new JButton("Room");
 		selectRoomBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( selectRoomBtn );
-		ctrlPanel.add( Box.createHorizontalStrut(5) );
-		JButton selectCrewBtn = new JButton("Crew");
+		selectPanel.add( selectRoomBtn );
+		selectPanel.add( Box.createHorizontalStrut(5) );
+		final JButton selectCrewBtn = new JButton("Crew");
 		selectCrewBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( selectCrewBtn );
-		ctrlPanel.add( Box.createHorizontalStrut(5) );
-		JButton selectBreachBtn = new JButton("Breach");
+		selectPanel.add( selectCrewBtn );
+		selectPanel.add( Box.createHorizontalStrut(5) );
+		final JButton selectBreachBtn = new JButton("Breach");
 		selectBreachBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( selectBreachBtn );
-		ctrlPanel.add( Box.createHorizontalStrut(5) );
-		JButton selectFireBtn = new JButton("Fire");
+		selectPanel.add( selectBreachBtn );
+		selectPanel.add( Box.createHorizontalStrut(5) );
+		final JButton selectFireBtn = new JButton("Fire");
 		selectFireBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( selectFireBtn );
+		selectPanel.add( selectFireBtn );
 
-		ctrlPanel.add( Box.createHorizontalStrut(15) );
-		ctrlPanel.add( new JLabel("Reset: ") );
-		JButton resetOxygenBtn = new JButton("Oxygen");
+		JPanel addPanel = new JPanel();
+		addPanel.setLayout( new BoxLayout(addPanel, BoxLayout.X_AXIS) );
+		addPanel.setBorder( BorderFactory.createTitledBorder("Add") );
+		final JButton addCrewBtn = new JButton("Crew");
+		addCrewBtn.setMargin(ctrlInsets);
+		addPanel.add( addCrewBtn );
+		addPanel.add( Box.createHorizontalStrut(5) );
+		final JButton addBreachBtn = new JButton("Breach");
+		addBreachBtn.setMargin(ctrlInsets);
+		addPanel.add( addBreachBtn );
+		addPanel.add( Box.createHorizontalStrut(5) );
+		final JButton addFireBtn = new JButton("Fire");
+		addFireBtn.setMargin(ctrlInsets);
+		addPanel.add( addFireBtn );
+
+		JPanel resetPanel = new JPanel();
+		resetPanel.setLayout( new BoxLayout(resetPanel, BoxLayout.X_AXIS) );
+		resetPanel.setBorder( BorderFactory.createTitledBorder("Reset") );
+		final JButton resetOxygenBtn = new JButton("Oxygen");
 		resetOxygenBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( resetOxygenBtn );
-		ctrlPanel.add( Box.createHorizontalStrut(5) );
-		JButton resetBreachesBtn = new JButton("Breaches");
+		resetPanel.add( resetOxygenBtn );
+		resetPanel.add( Box.createHorizontalStrut(5) );
+		final JButton resetIntrudersBtn = new JButton("Intruders");
+		resetIntrudersBtn.setMargin(ctrlInsets);
+		resetPanel.add( resetIntrudersBtn );
+		resetPanel.add( Box.createHorizontalStrut(5) );
+		final JButton resetBreachesBtn = new JButton("Breaches");
 		resetBreachesBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( resetBreachesBtn );
-		ctrlPanel.add( Box.createHorizontalStrut(5) );
-		JButton resetFiresBtn = new JButton("Fires");
+		resetPanel.add( resetBreachesBtn );
+		resetPanel.add( Box.createHorizontalStrut(5) );
+		final JButton resetFiresBtn = new JButton("Fires");
 		resetFiresBtn.setMargin(ctrlInsets);
-		ctrlPanel.add( resetFiresBtn );
+		resetPanel.add( resetFiresBtn );
 
-		selectRoomBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				selectRoom();
-			}
-		});
-		selectCrewBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				selectCrew();
-			}
-		});
-		selectBreachBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				selectBreach();
-			}
-		});
-		selectFireBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				selectFire();
-			}
-		});
+		JPanel ctrlRowOnePanel = new JPanel();
+		ctrlRowOnePanel.setLayout( new BoxLayout(ctrlRowOnePanel, BoxLayout.X_AXIS) );
+		ctrlRowOnePanel.add( selectPanel );
+		ctrlRowOnePanel.add( Box.createHorizontalStrut(15) );
+		ctrlRowOnePanel.add( addPanel );
 
-		resetOxygenBtn.addActionListener(new ActionListener() {
+		JPanel ctrlRowTwoPanel = new JPanel();
+		ctrlRowTwoPanel.setLayout( new BoxLayout(ctrlRowTwoPanel, BoxLayout.X_AXIS) );
+		ctrlRowTwoPanel.add( resetPanel );
+
+		JPanel ctrlPanel = new JPanel();
+		ctrlPanel.setLayout( new BoxLayout(ctrlPanel, BoxLayout.Y_AXIS) );
+		ctrlPanel.add( ctrlRowOnePanel );
+		ctrlPanel.add( Box.createVerticalStrut(8) );
+		ctrlPanel.add( ctrlRowTwoPanel );
+
+		ActionListener ctrlListener = new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
-				for (RoomSprite roomSprite : roomSprites) {
-					if ( roomSprite.getOxygen() != 100 ) {
-						roomSprite.setOxygen(100);
+				Object source = e.getSource();
+				if ( source == selectRoomBtn ) {
+					selectRoom();
+				} else if (source == selectCrewBtn ) {
+					selectCrew();
+				} else if (source == selectBreachBtn ) {
+					selectBreach();
+				} else if (source == selectFireBtn ) {
+					selectFire();
+				} else if (source == addCrewBtn ) {
+					addCrew();
+				} else if (source == addBreachBtn ) {
+					addBreach();
+				} else if (source == addFireBtn ) {
+					addFire();
+				} else if (source == resetOxygenBtn ) {
+					for (RoomSprite roomSprite : roomSprites) {
+						if ( roomSprite.getOxygen() != 100 ) {
+							roomSprite.setOxygen(100);
+						}
 					}
+					shipPanel.repaint();
+
+				} else if (source == resetIntrudersBtn ) {
+					for (ListIterator<CrewSprite> it = crewSprites.listIterator(); it.hasNext(); ) {
+						CrewSprite crewSprite = it.next();
+						if ( !crewSprite.isPlayerControlled() ) {
+							shipPanel.remove( crewSprite );
+							it.remove();
+						}
+					}
+					shipPanel.repaint();
+
+				} else if (source == resetBreachesBtn ) {
+					for (BreachSprite breachSprite : breachSprites)
+						shipPanel.remove( breachSprite );
+					breachSprites.clear();
+					shipPanel.repaint();
+
+				} else if (source == resetFiresBtn ) {
+					for (FireSprite fireSprite : fireSprites)
+						shipPanel.remove( fireSprite );
+					fireSprites.clear();
+					shipPanel.repaint();
 				}
-				shipPanel.repaint();
 			}
-		});
+		};
 
-		resetBreachesBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				for (BreachSprite breachSprite : breachSprites)
-					shipPanel.remove( breachSprite );
-				breachSprites.clear();
-				shipPanel.repaint();
-			}
-		});
+		selectRoomBtn.addActionListener( ctrlListener );
+		selectCrewBtn.addActionListener( ctrlListener );
+		selectBreachBtn.addActionListener( ctrlListener );
+		selectFireBtn.addActionListener( ctrlListener );
 
-		resetFiresBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				for (FireSprite fireSprite : fireSprites)
-					shipPanel.remove( fireSprite );
-				fireSprites.clear();
-				shipPanel.repaint();
-			}
-		});
+		addCrewBtn.addActionListener( ctrlListener );
+		addBreachBtn.addActionListener( ctrlListener );
+		addFireBtn.addActionListener( ctrlListener );
+
+		resetOxygenBtn.addActionListener( ctrlListener );
+		resetIntrudersBtn.addActionListener( ctrlListener );
+		resetBreachesBtn.addActionListener( ctrlListener );
+		resetFiresBtn.addActionListener( ctrlListener );
+
+		resetOxygenBtn.addMouseListener( new StatusbarMouseListener(frame, "Set all rooms' oxygen to 100%.") );
+		resetIntrudersBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all NPC crew.") );
+		resetBreachesBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all breaches.") );
+		resetFiresBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all fires.") );
 
 		JPanel centerPanel = new JPanel( new GridBagLayout() );
 
@@ -279,6 +335,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		gridC.gridx = 0;
 		gridC.gridy++;
 		centerPanel.add( ctrlPanel, gridC );
+
 		this.add( centerPanel, BorderLayout.CENTER );
 
 		sideScroll = new JScrollPane( sidePanel );
@@ -679,6 +736,83 @@ public class SavedGameFloorplanPanel extends JPanel {
 						break;
 					}
 				}
+				return true;
+			}
+		});
+		squareSelector.setVisible(true);
+	}
+
+	private void addCrew() {
+		squareSelector.reset();
+		squareSelector.setCriteria(new SquareCriteria() {
+			public boolean isSquareValid( int roomId, int squareId ) {
+				if ( roomId < 0 || squareId < 0 ) return false;
+				for (CrewSprite crewSprite : crewSprites) {
+					if ( crewSprite.getRoomId() == roomId && crewSprite.getSquareId() == squareId ) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+		squareSelector.setCallback(new SquareSelectionCallback() {
+			public boolean squareSelected( SquareSelector squareSelector, int roomId, int squareId ) {
+				Point center = squareSelector.getSquareCenter();
+				SavedGameParser.CrewState crewState = new SavedGameParser.CrewState();
+				crewState.setRoomId( roomId );
+				crewState.setRoomSquare( squareId );
+				crewState.setSpriteX( center.x - originX - tileEdge + shipLayout.getOffsetX()*squareSize );
+				crewState.setSpriteY( center.y - originY - tileEdge + shipLayout.getOffsetY()*squareSize );
+				addCrewSprite( center.x, center.y, crewState );
+				shipPanel.repaint();
+				return true;
+			}
+		});
+		squareSelector.setVisible(true);
+	}
+
+	private void addBreach() {
+		squareSelector.reset();
+		squareSelector.setCriteria(new SquareCriteria() {
+			public boolean isSquareValid( int roomId, int squareId ) {
+				if ( roomId < 0 || squareId < 0 ) return false;
+				for (BreachSprite breachSprite : breachSprites) {
+					if ( breachSprite.getRoomId() == roomId && breachSprite.getSquareId() == squareId ) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+		squareSelector.setCallback(new SquareSelectionCallback() {
+			public boolean squareSelected( SquareSelector squareSelector, int roomId, int squareId ) {
+				Point center = squareSelector.getSquareCenter();
+				addBreachSprite( center.x, center.y, roomId, squareId, 100 );
+				shipPanel.repaint();
+				return true;
+			}
+		});
+		squareSelector.setVisible(true);
+	}
+
+	private void addFire() {
+		squareSelector.reset();
+		squareSelector.setCriteria(new SquareCriteria() {
+			public boolean isSquareValid( int roomId, int squareId ) {
+				if ( roomId < 0 || squareId < 0 ) return false;
+				for (FireSprite fireSprite : fireSprites) {
+					if ( fireSprite.getRoomId() == roomId && fireSprite.getSquareId() == squareId ) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+		squareSelector.setCallback(new SquareSelectionCallback() {
+			public boolean squareSelected( SquareSelector squareSelector, int roomId, int squareId ) {
+				Point center = squareSelector.getSquareCenter();
+				addFireSprite( center.x, center.y, roomId, squareId, 100 );
+				shipPanel.repaint();
 				return true;
 			}
 		});

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -1312,6 +1312,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		sidePanel.removeAll();
 
 		sidePanel.revalidate();
+		this.revalidate();
 		this.repaint();
 	}
 

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -581,7 +581,6 @@ public class SavedGameFloorplanPanel extends JPanel {
 			shipPanel.add( roomSprite, OXYGEN_LAYER );
 		}
 
-		// Associate systems' normal names with their image basenames.
 		ArrayList<String> systemIds = new ArrayList<String>();
 		systemIds.add( SystemBlueprint.ID_PILOT );
 		systemIds.add( SystemBlueprint.ID_DOORS );

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -235,6 +235,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 		resetOxygenBtn.setMargin(ctrlInsets);
 		resetPanel.add( resetOxygenBtn );
 		resetPanel.add( Box.createHorizontalStrut(5) );
+		final JButton resetSystemsBtn = new JButton("Systems");
+		resetSystemsBtn.setMargin(ctrlInsets);
+		resetPanel.add( resetSystemsBtn );
+		resetPanel.add( Box.createHorizontalStrut(5) );
 		final JButton resetIntrudersBtn = new JButton("Intruders");
 		resetIntrudersBtn.setMargin(ctrlInsets);
 		resetPanel.add( resetIntrudersBtn );
@@ -291,6 +295,17 @@ public class SavedGameFloorplanPanel extends JPanel {
 					}
 					shipPanel.repaint();
 
+				} else if (source == resetSystemsBtn ) {
+					clearSidePanel();
+					for (SystemSprite systemSprite : systemSprites) {
+						systemSprite.setDamagedBars(0);
+						systemSprite.setIonizedBars(0);
+						systemSprite.setRepairProgress(0);
+						systemSprite.setDamageProgress(0);
+						systemSprite.setDeionizationTicks(Integer.MIN_VALUE);
+					}
+					shipPanel.repaint();
+
 				} else if (source == resetIntrudersBtn ) {
 					clearSidePanel();
 					for (ListIterator<CrewSprite> it = crewSprites.listIterator(); it.hasNext(); ) {
@@ -330,11 +345,13 @@ public class SavedGameFloorplanPanel extends JPanel {
 		addFireBtn.addActionListener( ctrlListener );
 
 		resetOxygenBtn.addActionListener( ctrlListener );
+		resetSystemsBtn.addActionListener( ctrlListener );
 		resetIntrudersBtn.addActionListener( ctrlListener );
 		resetBreachesBtn.addActionListener( ctrlListener );
 		resetFiresBtn.addActionListener( ctrlListener );
 
 		resetOxygenBtn.addMouseListener( new StatusbarMouseListener(frame, "Set all rooms' oxygen to 100%.") );
+		resetSystemsBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all system damage.") );
 		resetIntrudersBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all NPC crew.") );
 		resetBreachesBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all breaches.") );
 		resetFiresBtn.addMouseListener( new StatusbarMouseListener(frame, "Remove all fires.") );

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -61,6 +61,7 @@ import net.blerf.ftl.ui.FTLFrame;
 import net.blerf.ftl.ui.StatusbarMouseListener;
 import net.blerf.ftl.xml.ShipBlueprint;
 import net.blerf.ftl.xml.ShipChassis;
+import net.blerf.ftl.xml.SystemBlueprint;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -581,22 +582,22 @@ public class SavedGameFloorplanPanel extends JPanel {
 		}
 
 		// Associate systems' normal names with their image basenames.
-		HashMap<String, String> systemNames = new HashMap<String, String>();
-		systemNames.put( ShipBlueprint.SystemList.NAME_PILOT, "pilot" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_DOORS, "doors" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_SENSORS, "sensors" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_MEDBAY, "medbay" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_OXYGEN, "oxygen" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_SHIELDS, "shields" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_ENGINES, "engines" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_WEAPONS, "weapons" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_DRONE_CTRL, "drones" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_TELEPORTER, "teleporter" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_CLOAKING, "cloaking" );
-		systemNames.put( ShipBlueprint.SystemList.NAME_ARTILLERY, "artillery" );
+		ArrayList<String> systemIds = new ArrayList<String>();
+		systemIds.add( SystemBlueprint.ID_PILOT );
+		systemIds.add( SystemBlueprint.ID_DOORS );
+		systemIds.add( SystemBlueprint.ID_SENSORS );
+		systemIds.add( SystemBlueprint.ID_MEDBAY );
+		systemIds.add( SystemBlueprint.ID_OXYGEN );
+		systemIds.add( SystemBlueprint.ID_SHIELDS );
+		systemIds.add( SystemBlueprint.ID_ENGINES );
+		systemIds.add( SystemBlueprint.ID_WEAPONS );
+		systemIds.add( SystemBlueprint.ID_DRONE_CTRL );
+		systemIds.add( SystemBlueprint.ID_TELEPORTER );
+		systemIds.add( SystemBlueprint.ID_CLOAKING );
+		systemIds.add( SystemBlueprint.ID_ARTILLERY );
 
-		for (Map.Entry<String, String> entry : systemNames.entrySet()) {
-			int[] roomIds = shipBlueprint.getSystemList().getRoomIdBySystemName( entry.getKey() );
+		for (String systemId : systemIds) {
+			int[] roomIds = shipBlueprint.getSystemList().getRoomIdBySystemId( systemId );
 			if ( roomIds != null ) {
 				for (int i=0; i < roomIds.length; i++) {
 					EnumMap<ShipLayout.RoomInfo, Integer> roomInfoMap = shipLayout.getRoomInfo( roomIds[i] );
@@ -606,9 +607,10 @@ public class SavedGameFloorplanPanel extends JPanel {
 					int roomY = originY + squareSize * roomLocY;
 					int squaresH = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_H ).intValue();
 					int squaresV = roomInfoMap.get( ShipLayout.RoomInfo.SQUARES_V ).intValue();
+
 					int systemX = roomX + tileEdge + squaresH*squareSize/2;
 					int systemY = roomY + tileEdge + squaresV*squareSize/2;
-					addSystemSprite( systemX, systemY, entry.getValue() );
+					addSystemSprite( systemX, systemY, systemId );  // Assumes systemId is the image basename.
 				}
 			}
 		}
@@ -658,7 +660,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		}
 
 		// Add doors.
-		int doorLevel = shipState.getSystem("Doors").getCapacity()-1;  // Convert to 0-based.
+		int doorLevel = shipState.getSystem(SystemBlueprint.ID_DOORS).getCapacity()-1;  // Convert to 0-based.
 		for (Map.Entry<ShipLayout.DoorCoordinate, SavedGameParser.DoorState> entry : shipState.getDoorMap().entrySet()) {
 			ShipLayout.DoorCoordinate doorCoord = entry.getKey();
 			SavedGameParser.DoorState doorState = entry.getValue();
@@ -1185,7 +1187,6 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 	/** Draws each room's walls, door openings, and floor crevices. */
 	private void drawWalls( Graphics2D wallG, int originX, int originY, SavedGameParser.ShipState shipState, ShipLayout shipLayout ) {
-		int doorLevel = shipState.getSystem("Doors").getCapacity()-1;  // Convert to 0-based.
 
 		Color prevColor = wallG.getColor();
 		Stroke prevStroke = wallG.getStroke();
@@ -1473,7 +1474,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 		final String OPEN = "Open";
 		final String WALKING_THROUGH = "Walking Through";
 
-		String title = "Door";
+		ShipLayout.DoorCoordinate doorCoord = doorSprite.getCoordinate();
+		String title = String.format("Door (%2d,%2d, %s)", doorCoord.x, doorCoord.y, (doorCoord.v==1 ? "V" : "H"));
 
 		final FieldEditorPanel editorPanel = new FieldEditorPanel( false );
 		editorPanel.addRow( OPEN, FieldEditorPanel.ContentType.BOOLEAN );

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -268,6 +268,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 				} else if (source == addFireBtn ) {
 					addFire();
 				} else if (source == resetOxygenBtn ) {
+					clearSidePanel();
 					for (RoomSprite roomSprite : roomSprites) {
 						if ( roomSprite.getOxygen() != 100 ) {
 							roomSprite.setOxygen(100);
@@ -276,6 +277,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 					shipPanel.repaint();
 
 				} else if (source == resetIntrudersBtn ) {
+					clearSidePanel();
 					for (ListIterator<CrewSprite> it = crewSprites.listIterator(); it.hasNext(); ) {
 						CrewSprite crewSprite = it.next();
 						if ( !crewSprite.isPlayerControlled() ) {
@@ -286,12 +288,14 @@ public class SavedGameFloorplanPanel extends JPanel {
 					shipPanel.repaint();
 
 				} else if (source == resetBreachesBtn ) {
+					clearSidePanel();
 					for (BreachSprite breachSprite : breachSprites)
 						shipPanel.remove( breachSprite );
 					breachSprites.clear();
 					shipPanel.repaint();
 
 				} else if (source == resetFiresBtn ) {
+					clearSidePanel();
 					for (FireSprite fireSprite : fireSprites)
 						shipPanel.remove( fireSprite );
 					fireSprites.clear();
@@ -534,15 +538,15 @@ public class SavedGameFloorplanPanel extends JPanel {
 					}
 				}
 			}
-		}
 
-		// Draw walls and floor crevices.
-		BufferedImage wallImage = gc.createCompatibleImage( floorLbl.getIcon().getIconWidth(), floorLbl.getIcon().getIconHeight(), Transparency.BITMASK );
-		Graphics2D wallG = (Graphics2D)wallImage.createGraphics();
-		drawWalls( wallG, originX, originY, shipState, shipLayout );
-		wallG.dispose();
-		wallLbl.setIcon( new ImageIcon(wallImage) );
-		wallLbl.setSize( new Dimension(wallImage.getWidth(), wallImage.getHeight()) );
+			// Draw walls and floor crevices.
+			BufferedImage wallImage = gc.createCompatibleImage( floorLbl.getIcon().getIconWidth(), floorLbl.getIcon().getIconHeight(), Transparency.BITMASK );
+			Graphics2D wallG = (Graphics2D)wallImage.createGraphics();
+			drawWalls( wallG, originX, originY, shipState, shipLayout );
+			wallG.dispose();
+			wallLbl.setIcon( new ImageIcon(wallImage) );
+			wallLbl.setSize( new Dimension(wallImage.getWidth(), wallImage.getHeight()) );
+		}
 
 		// Add oxygen.
 		for (int i=0; i < shipLayout.getRoomCount(); i++) {

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -101,6 +101,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 	private JLayeredPane shipPanel = null;
 	private JPanel sidePanel = null;
+	private JScrollPane sideScroll = null;
+
 	private JLabel baseLbl = null;
 	private JLabel floorLbl = null;
 	private JLabel wallLbl = null;
@@ -108,7 +110,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 	private SquareSelector squareSelector = null;
 
 	public SavedGameFloorplanPanel( FTLFrame frame ) {
-		super( new GridBagLayout() );
+		super( new BorderLayout() );
 		this.frame = frame;
 
 		shipPanel = new JLayeredPane();
@@ -118,6 +120,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 
 		sidePanel = new JPanel();
 		sidePanel.setLayout( new BoxLayout(sidePanel, BoxLayout.Y_AXIS) );
+		sidePanel.setBorder( BorderFactory.createEmptyBorder(4, 4, 4, 6) );
 
 		baseLbl = new JLabel();
 		baseLbl.setOpaque(false);
@@ -169,28 +172,38 @@ public class SavedGameFloorplanPanel extends JPanel {
 		squareSelector.addMouseListener( squareListener );
 		squareSelector.addMouseMotionListener( squareListener );
 
+		Insets ctrlInsets = new Insets(3, 4, 3, 4);
 		JPanel ctrlPanel = new JPanel();
 		ctrlPanel.setLayout( new BoxLayout(ctrlPanel, BoxLayout.X_AXIS) );
 		ctrlPanel.add( new JLabel("Select: ") );
 		JButton selectRoomBtn = new JButton("Room");
+		selectRoomBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( selectRoomBtn );
 		ctrlPanel.add( Box.createHorizontalStrut(5) );
 		JButton selectCrewBtn = new JButton("Crew");
+		selectCrewBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( selectCrewBtn );
 		ctrlPanel.add( Box.createHorizontalStrut(5) );
 		JButton selectBreachBtn = new JButton("Breach");
+		selectBreachBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( selectBreachBtn );
 		ctrlPanel.add( Box.createHorizontalStrut(5) );
 		JButton selectFireBtn = new JButton("Fire");
+		selectFireBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( selectFireBtn );
 
 		ctrlPanel.add( Box.createHorizontalStrut(15) );
 		ctrlPanel.add( new JLabel("Reset: ") );
 		JButton resetOxygenBtn = new JButton("Oxygen");
+		resetOxygenBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( resetOxygenBtn );
+		ctrlPanel.add( Box.createHorizontalStrut(5) );
 		JButton resetBreachesBtn = new JButton("Breaches");
+		resetBreachesBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( resetBreachesBtn );
+		ctrlPanel.add( Box.createHorizontalStrut(5) );
 		JButton resetFiresBtn = new JButton("Fires");
+		resetFiresBtn.setMargin(ctrlInsets);
 		ctrlPanel.add( resetFiresBtn );
 
 		selectRoomBtn.addActionListener(new ActionListener() {
@@ -243,6 +256,8 @@ public class SavedGameFloorplanPanel extends JPanel {
 			}
 		});
 
+		JPanel centerPanel = new JPanel( new GridBagLayout() );
+
 		GridBagConstraints gridC = new GridBagConstraints();
 
 		gridC.fill = GridBagConstraints.BOTH;
@@ -253,26 +268,24 @@ public class SavedGameFloorplanPanel extends JPanel {
 		JScrollPane shipScroll = new JScrollPane( shipPanel );
 		shipScroll.setVerticalScrollBarPolicy( JScrollPane.VERTICAL_SCROLLBAR_ALWAYS );
 		shipScroll.setHorizontalScrollBarPolicy( JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS );
-		this.add( shipScroll, gridC );
+		centerPanel.add( shipScroll, gridC );
 
 		gridC.insets = new Insets(4, 4, 4, 4);
-
-		gridC.anchor = GridBagConstraints.NORTH;
-		gridC.fill = GridBagConstraints.NONE;
-		gridC.weightx = 0.0;
-		gridC.weighty = 0.0;
-		gridC.gridheight = 2;
-		gridC.gridx++;
-		this.add( sidePanel, gridC );
 
 		gridC.anchor = GridBagConstraints.CENTER;
 		gridC.fill = GridBagConstraints.HORIZONTAL;
 		gridC.weightx = 1.0;
 		gridC.weighty = 0.0;
-		gridC.gridheight = 1;
 		gridC.gridx = 0;
 		gridC.gridy++;
-		this.add( ctrlPanel, gridC );
+		centerPanel.add( ctrlPanel, gridC );
+		this.add( centerPanel, BorderLayout.CENTER );
+
+		sideScroll = new JScrollPane( sidePanel );
+		sideScroll.setVerticalScrollBarPolicy( JScrollPane.VERTICAL_SCROLLBAR_ALWAYS );
+		sideScroll.setHorizontalScrollBarPolicy( JScrollPane.HORIZONTAL_SCROLLBAR_NEVER );
+		sideScroll.setVisible( false );
+		this.add( sideScroll, BorderLayout.EAST );
 	}
 
 	public void setGameState( SavedGameParser.SavedGameState gameState ) {
@@ -923,19 +936,33 @@ public class SavedGameFloorplanPanel extends JPanel {
 		wallG.setStroke( prevStroke );
 	}
 
+	private void showSidePanel() {
+		sidePanel.revalidate();
+		int sideWidth = sidePanel.getPreferredSize().width;
+		int vbarWidth = sideScroll.getVerticalScrollBar().getPreferredSize().width;
+		sideScroll.setPreferredSize( new Dimension(sideWidth + vbarWidth, 1) );
+		sideScroll.setVisible( true );
+
+		this.revalidate();
+		this.repaint();
+	}
+
 	private void clearSidePanel() {
+		sideScroll.setVisible( false );
 		sidePanel.removeAll();
+
 		sidePanel.revalidate();
 		this.repaint();
 	}
 
 	/**
-	 * Populates the sidepanel.
-	 * Includes a title, arbitrary content,
-	 * and cancel/apply buttons.
+	 * Clears and ropulates the side panel.
+	 * Includes a title, arbitrary content, and
+	 * cancel/apply buttons.
 	 *
-	 * Afterward, revalidate() and repaint()
-	 * should be called.
+	 * More can be added to the side panel manually.
+	 *
+	 * Afterward, showSidePanel() should be called.
 	 */
 	private void createSidePanel( String title, final FieldEditorPanel editorPanel, final Runnable applyCallback ) {
 		clearSidePanel();
@@ -943,9 +970,13 @@ public class SavedGameFloorplanPanel extends JPanel {
 		titleLbl.setAlignmentX( Component.CENTER_ALIGNMENT );
 		sidePanel.add( titleLbl );
 		sidePanel.add( Box.createVerticalStrut(4) );
-		sidePanel.add( new JSeparator(JSeparator.HORIZONTAL) );
+		JSeparator titleSep = new JSeparator(JSeparator.HORIZONTAL);
+		titleSep.setMaximumSize( new Dimension(Short.MAX_VALUE, titleSep.getPreferredSize().height) );
+		sidePanel.add( titleSep );
 		sidePanel.add( Box.createVerticalStrut(4) );
 
+		// Keep the editor from growing and creating gaps around it.
+		editorPanel.setMaximumSize(editorPanel.getPreferredSize());
 		sidePanel.add( editorPanel );
 
 		sidePanel.add( Box.createVerticalStrut(10) );
@@ -954,7 +985,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		applyPanel.setLayout( new BoxLayout(applyPanel, BoxLayout.X_AXIS) );
 		JButton cancelBtn = new JButton("Cancel");
 		applyPanel.add( cancelBtn );
-		applyPanel.add( Box.createHorizontalStrut(15) );
+		applyPanel.add( Box.createRigidArea( new Dimension(15, 1)) );
 		JButton applyBtn = new JButton("Apply");
 		applyPanel.add( applyBtn );
 		sidePanel.add( applyPanel );
@@ -993,8 +1024,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		};
 		createSidePanel( title, editorPanel, applyCallback );
 
-		sidePanel.revalidate();
-		this.repaint();
+		showSidePanel();
 	}
 
 	private void showBreachEditor( final BreachSprite breachSprite ) {
@@ -1017,8 +1047,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		};
 		createSidePanel( title, editorPanel, applyCallback );
 
-		sidePanel.revalidate();
-		this.repaint();
+		showSidePanel();
 	}
 
 	private void showFireEditor( final FireSprite fireSprite ) {
@@ -1041,8 +1070,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		};
 		createSidePanel( title, editorPanel, applyCallback );
 
-		sidePanel.revalidate();
-		this.repaint();
+		showSidePanel();
 	}
 
 	private void showCrewEditor( final CrewSprite crewSprite ) {
@@ -1168,8 +1196,7 @@ public class SavedGameFloorplanPanel extends JPanel {
 		};
 		createSidePanel( title, editorPanel, applyCallback );
 
-		sidePanel.revalidate();
-		this.repaint();
+		showSidePanel();
 	}
 
 

--- a/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/SavedGameFloorplanPanel.java
@@ -1515,11 +1515,11 @@ public class SavedGameFloorplanPanel extends JPanel {
 		editorPanel.getInt(IONIZED_BARS).addMouseListener( new StatusbarMouseListener(frame, String.format("Ionized bars (can exceed %d but the number won't appear in-game).", SavedGameParser.SystemState.MAX_IONIZED_BARS)) );
 		editorPanel.addBlankRow();
 		editorPanel.addRow( REPAIR_PROGRESS, FieldEditorPanel.ContentType.SLIDER );
-		editorPanel.getSlider(REPAIR_PROGRESS).setMaximum( 100 );
+		editorPanel.getSlider(REPAIR_PROGRESS).setMaximum( (systemSprite.getDamagedBars() == 0 ? 0 : 100) );
 		editorPanel.getSlider(REPAIR_PROGRESS).setValue( systemSprite.getRepairProgress() );
 		editorPanel.getSlider(REPAIR_PROGRESS).addMouseListener( new StatusbarMouseListener(frame, "Turns a damaged bar yellow until restored.") );
 		editorPanel.addRow( DAMAGE_PROGRESS, FieldEditorPanel.ContentType.SLIDER );
-		editorPanel.getSlider(DAMAGE_PROGRESS).setMaximum( 100 );
+		editorPanel.getSlider(DAMAGE_PROGRESS).setMaximum( (systemSprite.getDamagedBars() >= systemSprite.getCapacity() ? 0 : 100) );
 		editorPanel.getSlider(DAMAGE_PROGRESS).setValue( systemSprite.getDamageProgress() );
 		editorPanel.getSlider(DAMAGE_PROGRESS).addMouseListener( new StatusbarMouseListener(frame, "Turns an undamaged bar red until damaged.") );
 		editorPanel.addRow( DEIONIZATION_TICKS, FieldEditorPanel.ContentType.INTEGER );

--- a/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
@@ -28,10 +28,10 @@ public class ShipBlueprint {
 	
 	private SystemList systemList;
 	private Health health;
-	
+	private MaxPower maxPower;
 	private int weaponSlots, droneSlots;
 	
-	private Object weaponList, maxPower, crewCount; // TODO model
+	private Object weaponList, crewCount; // TODO model
 	
 	@XmlRootElement
 	@XmlAccessorType(XmlAccessType.FIELD)
@@ -286,6 +286,13 @@ public class ShipBlueprint {
 		public int amount;
 	}
 
+	@XmlRootElement
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class MaxPower {
+		@XmlAttribute
+		public int amount;
+	}
+
 	public String getId() {
 		return id;
 	}
@@ -374,11 +381,11 @@ public class ShipBlueprint {
 		this.health = health;
 	}
 
-	public Object getMaxPower() {
+	public MaxPower getMaxPower() {
 		return maxPower;
 	}
 
-	public void setMaxPower(Object maxPower) {
+	public void setMaxPower(MaxPower maxPower) {
 		this.maxPower = maxPower;
 	}
 

--- a/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipBlueprint.java
@@ -9,6 +9,8 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import net.blerf.ftl.xml.SystemBlueprint;
+
 @XmlRootElement(name="shipBlueprint")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ShipBlueprint {
@@ -34,19 +36,6 @@ public class ShipBlueprint {
 	@XmlRootElement
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class SystemList {
-
-		public static final String NAME_PILOT = "Pilot";
-		public static final String NAME_DOORS = "Doors";
-		public static final String NAME_SENSORS = "Sensors";
-		public static final String NAME_MEDBAY = "Medbay";
-		public static final String NAME_OXYGEN = "Oxygen";
-		public static final String NAME_SHIELDS = "Shields";
-		public static final String NAME_ENGINES = "Engines";
-		public static final String NAME_WEAPONS = "Weapons";
-		public static final String NAME_DRONE_CTRL = "Drone Ctrl";
-		public static final String NAME_TELEPORTER = "Teleporter";
-		public static final String NAME_CLOAKING = "Cloaking";
-		public static final String NAME_ARTILLERY = "Artillery";
 
 		@XmlRootElement
 		@XmlAccessorType(XmlAccessType.FIELD)
@@ -230,47 +219,52 @@ public class ShipBlueprint {
 		}
 
 		/**
-		 * Returns the system's name in a given room, or null.
+		 * Returns the systemId in a given room, or null.
+		 *
+		 * @return one of SystemBlueprint's ID_* constants.
 		 */
-		public String getSystemNameByRoomId( int roomId ) {
-			if ( getPilotRoom() != null && getPilotRoom().getRoomId() == roomId ) return NAME_PILOT;
-			if ( getDoorsRoom() != null && getDoorsRoom().getRoomId() == roomId ) return NAME_DOORS;
-			if ( getSensorsRoom() != null && getSensorsRoom().getRoomId() == roomId ) return NAME_SENSORS;
-			if ( getMedicalRoom() != null && getMedicalRoom().getRoomId() == roomId ) return NAME_MEDBAY;
-			if ( getLifeSupportRoom() != null && getLifeSupportRoom().getRoomId() == roomId ) return NAME_OXYGEN;
-			if ( getShieldRoom() != null && getShieldRoom().getRoomId() == roomId ) return NAME_SHIELDS;
-			if ( getEngineRoom() != null && getEngineRoom().getRoomId() == roomId ) return NAME_ENGINES;
-			if ( getWeaponRoom() != null && getWeaponRoom().getRoomId() == roomId ) return NAME_WEAPONS;
-			if ( getDroneRoom() != null && getDroneRoom().getRoomId() == roomId ) return NAME_DRONE_CTRL;
-			if ( getTeleporterRoom() != null && getTeleporterRoom().getRoomId() == roomId ) return NAME_TELEPORTER;
-			if ( getCloakRoom() != null && getCloakRoom().getRoomId() == roomId ) return NAME_CLOAKING;
+		public String getSystemIdByRoomId( int roomId ) {
+			if ( getPilotRoom() != null && getPilotRoom().getRoomId() == roomId ) return SystemBlueprint.ID_PILOT;
+			if ( getDoorsRoom() != null && getDoorsRoom().getRoomId() == roomId ) return SystemBlueprint.ID_DOORS;
+			if ( getSensorsRoom() != null && getSensorsRoom().getRoomId() == roomId ) return SystemBlueprint.ID_SENSORS;
+			if ( getMedicalRoom() != null && getMedicalRoom().getRoomId() == roomId ) return SystemBlueprint.ID_MEDBAY;
+			if ( getLifeSupportRoom() != null && getLifeSupportRoom().getRoomId() == roomId ) return SystemBlueprint.ID_OXYGEN;
+			if ( getShieldRoom() != null && getShieldRoom().getRoomId() == roomId ) return SystemBlueprint.ID_SHIELDS;
+			if ( getEngineRoom() != null && getEngineRoom().getRoomId() == roomId ) return SystemBlueprint.ID_ENGINES;
+			if ( getWeaponRoom() != null && getWeaponRoom().getRoomId() == roomId ) return SystemBlueprint.ID_WEAPONS;
+			if ( getDroneRoom() != null && getDroneRoom().getRoomId() == roomId ) return SystemBlueprint.ID_DRONE_CTRL;
+			if ( getTeleporterRoom() != null && getTeleporterRoom().getRoomId() == roomId ) return SystemBlueprint.ID_TELEPORTER;
+			if ( getCloakRoom() != null && getCloakRoom().getRoomId() == roomId ) return SystemBlueprint.ID_CLOAKING;
 			if ( getArtilleryRooms() != null ) {
 				for ( SystemRoom artilleryRoom : artilleryRooms ) {
-					if ( artilleryRoom.getRoomId() == roomId ) return NAME_ARTILLERY;
+					if ( artilleryRoom.getRoomId() == roomId ) return SystemBlueprint.ID_ARTILLERY;
 				}
 			}
 			return null;
 		}
 
 		/**
-		 * Returns a system's roomId(s), or null.
+		 * Returns roomId(s) that contain a given system, or null.
+		 *
+		 * @param name one of SystemBlueprint's ID_* constants.
+		 * @return a list of roomIds, usually only containing one
 		 */
-		public int[] getRoomIdBySystemName( String name ) {
+		public int[] getRoomIdBySystemId( String systemId ) {
 			SystemList.SystemRoom systemRoom = null;
-			if ( name.equals(NAME_PILOT) ) systemRoom = getPilotRoom();
-			else if ( name.equals(NAME_DOORS) ) systemRoom = getDoorsRoom();
-			else if ( name.equals(NAME_SENSORS) ) systemRoom = getSensorsRoom();
-			else if ( name.equals(NAME_MEDBAY) ) systemRoom = getMedicalRoom();
-			else if ( name.equals(NAME_OXYGEN) ) systemRoom = getLifeSupportRoom();
-			else if ( name.equals(NAME_SHIELDS) ) systemRoom = getShieldRoom();
-			else if ( name.equals(NAME_ENGINES) ) systemRoom = getEngineRoom();
-			else if ( name.equals(NAME_WEAPONS) ) systemRoom = getWeaponRoom();
-			else if ( name.equals(NAME_DRONE_CTRL) ) systemRoom = getDroneRoom();
-			else if ( name.equals(NAME_TELEPORTER) ) systemRoom = getTeleporterRoom();
-			else if ( name.equals(NAME_CLOAKING) ) systemRoom = getCloakRoom();
+			if ( systemId.equals(SystemBlueprint.ID_PILOT) ) systemRoom = getPilotRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_DOORS) ) systemRoom = getDoorsRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_SENSORS) ) systemRoom = getSensorsRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_MEDBAY) ) systemRoom = getMedicalRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_OXYGEN) ) systemRoom = getLifeSupportRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_SHIELDS) ) systemRoom = getShieldRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_ENGINES) ) systemRoom = getEngineRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_WEAPONS) ) systemRoom = getWeaponRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_DRONE_CTRL) ) systemRoom = getDroneRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_TELEPORTER) ) systemRoom = getTeleporterRoom();
+			else if ( systemId.equals(SystemBlueprint.ID_CLOAKING) ) systemRoom = getCloakRoom();
 			if ( systemRoom != null ) return new int[] { systemRoom.getRoomId() };
 
-			if ( name.equals(NAME_ARTILLERY) ) {
+			if ( systemId.equals(SystemBlueprint.ID_ARTILLERY) ) {
 				if ( getArtilleryRooms() != null && getArtilleryRooms().size() > 0 ) {
 					int n = 0;
 					int[] result = new int[getArtilleryRooms().size()];

--- a/src/main/java/net/blerf/ftl/xml/ShipChassis.java
+++ b/src/main/java/net/blerf/ftl/xml/ShipChassis.java
@@ -13,25 +13,27 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class ShipChassis {
 	@XmlElement(name="img")
 	private ChassisImageBounds imageBounds;
+	@XmlElement(name="weaponMounts")
 	private WeaponMountList weaponMountList;
 
-	@XmlRootElement(name="img")
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class ChassisImageBounds {
 		@XmlAttribute
 		public int x, y, w, h;
 	}
 
-	@XmlRootElement(name="weaponMounts")
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class WeaponMountList {
-		private List<WeaponMount> mount;
+		@XmlElement(name="mount")
+		public List<WeaponMount> mount;
 
-		@XmlRootElement(name="mount")
 		@XmlAccessorType(XmlAccessType.FIELD)
 		public static class WeaponMount {
+			@XmlAttribute
 			public int x, y, gib;
+			@XmlAttribute
 			public boolean rotate, mirror;
+			@XmlAttribute
 			public String slide;
 		}
 	}
@@ -51,6 +53,7 @@ public class ShipChassis {
 
 			@XmlAccessorType(XmlAccessType.FIELD)
 			public static class FloatRange {
+				@XmlAttribute
 				private float min, max;
 			}
 		}

--- a/src/main/java/net/blerf/ftl/xml/SystemBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/SystemBlueprint.java
@@ -4,13 +4,29 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="systemBlueprint")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class SystemBlueprint {
-	
+
+	public static final String ID_PILOT = "pilot";
+	public static final String ID_DOORS = "doors";
+	public static final String ID_SENSORS = "sensors";
+	public static final String ID_MEDBAY = "medbay";
+	public static final String ID_OXYGEN = "oxygen";
+	public static final String ID_SHIELDS = "shields";
+	public static final String ID_ENGINES = "engines";
+	public static final String ID_WEAPONS = "weapons";
+	public static final String ID_DRONE_CTRL = "drones";
+	public static final String ID_TELEPORTER = "teleporter";
+	public static final String ID_CLOAKING = "cloaking";
+	public static final String ID_ARTILLERY = "artillery";
+
+	@XmlAttribute(name="name")
+	private String id;
 	private String type, title, desc;
 	private int startPower, maxPower, rarity;
 	private UpgradeCost upgradeCost;
@@ -22,6 +38,93 @@ public class SystemBlueprint {
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class UpgradeCost {
 		private List<Integer> level;
+
+		public List<Integer> getLevel() {
+			return level;
+		}
+
+		public void setLevel(List<Integer> level) {
+			this.level = level;
+		}
 	}
 
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getDescription() {
+		return desc;
+	}
+
+	public void setDescription(String desc) {
+		this.type = desc;
+	}
+
+	public int getStartPower() {
+		return startPower;
+	}
+
+	public void setStartPower(int startPower) {
+		this.startPower = startPower;
+	}
+
+	public int getMaxPower() {
+		return maxPower;
+	}
+
+	public void setMaxPower(int maxPower) {
+		this.maxPower = maxPower;
+	}
+
+	public int getRarity() {
+		return rarity;
+	}
+
+	public void setRarity(int rarity) {
+		this.rarity = rarity;
+	}
+
+	public UpgradeCost getUpgradeCost() {
+		return upgradeCost;
+	}
+
+	public void setUpgradeCost(UpgradeCost upgradeCost) {
+		this.upgradeCost = upgradeCost;
+	}
+
+	public int getCost() {
+		return cost;
+	}
+
+	public void setCost(int cost) {
+		this.cost = cost;
+	}
+
+	public int getLocked() {
+		return locked;
+	}
+
+	public void setLocked(int locked) {
+		this.locked = locked;
+	}
 }

--- a/src/main/java/net/blerf/ftl/xml/SystemBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/SystemBlueprint.java
@@ -25,6 +25,14 @@ public class SystemBlueprint {
 	public static final String ID_CLOAKING = "cloaking";
 	public static final String ID_ARTILLERY = "artillery";
 
+	public static boolean isSubsystem( String systemId ) {
+		if ( systemId == null ) return false;
+		if ( systemId.equals(ID_PILOT) ) return true;
+		if ( systemId.equals(ID_DOORS) ) return true;
+		if ( systemId.equals(ID_SENSORS) ) return true;
+		return false;
+	}
+
 	@XmlAttribute(name="name")
 	private String id;
 	private String type, title, desc;

--- a/src/main/java/net/blerf/ftl/xml/WeaponBlueprint.java
+++ b/src/main/java/net/blerf/ftl/xml/WeaponBlueprint.java
@@ -154,4 +154,8 @@ public class WeaponBlueprint {
 	public void setRarity( int rarity ) {
 		this.rarity = rarity;
 	}
+
+	public String toString() {
+		return ""+title;
+	}
 }


### PR DESCRIPTION
FloorplanPanel
- Every field of breaches, fires, crew, doors, systems, and weapons is editable.
- Room editing covers oxygen, and squares' ignitionProgress and unknown gamma.
- The side panel is scrollable.
- Breaches, fires, and crew can be added (limit one crew per square for now).
- All intruders can be removed with a new reset button.
- All system damage can be cleared with another reset button.
- Room decorations.
- Square selectors avoid blocked squares.

SystemId constants in SystemBlueprint became the standard by which systems are looked up.

Crew races/flags should be safe.

Setting Weapons/DroneCtrl system power independently of their weapons/drones makes FTL lag horribly, presumably throwing tones of errors under the hood.

So Weapons system power is determined by each weapon item's armed state. When editing the Weapons system, weapon items will be properly disarmed if capacity/damage reduce available power.

System editing doesn't disarm drones yet when it cuts power, which is bad.
